### PR TITLE
feat (dprint): add adprint as formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+	// default formatter
+  "editor.defaultFormatter": "dprint.dprint",
+  "editor.formatOnSave": true,
+
+	// language settings
+
+}

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1,3 +1,3 @@
 // Hello World with types
-const username: string = "atsushifx";
+const username: string = 'atsushifx';
 console.log(`Hello, ${username}!`);

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://dprint.dev/schemas/v0.json",
+	"lineWidth": 120,
+	"indentWidth": 2,
+	"useTabs": false,
+	"newLineKind": "lf",
+	"typescript": {
+		"indentWidth": 4,
+		"useTabs": true,
+		"quoteStyle": "preferSingle"
+	},
+	"json": {},
+	"markdown": {},
+	"yaml": {},
+	"includes": [
+		"**/*.ts"
+	],
+	"excludes": [
+		"**/node_modules",
+		"**/*-lock.json"
+	],
+	"plugins": [
+		"https://plugins.dprint.dev/typescript-0.93.4.wasm",
+		"https://plugins.dprint.dev/json-0.19.4.wasm",
+		"https://plugins.dprint.dev/markdown-0.17.8.wasm",
+		"https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm"
+	]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
 	"type": "module",
 	"packageManager": "pnpm@10.4.1",
 	"devDependencies": {
-		"@types/node": "^22.13.4",
 		"typescript": "^5.7.3"
 	}
 }


### PR DESCRIPTION

- dprint: add dprint config to root (vscode extension can read only project root)
- vscode settings: add vscode settings to use dprint as default formatter
- packages: remmove @types/node → move to developpers devDependencies(future)