### PR TITLE
docs(dsl/prompt): improve markdown formatting and linter configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+// src: .vscode/settings.json
+// @(#): vscode settings for this workspace
+//
+// Copyright (c) 2025- atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+{
+  "files.associations": {
+    "*.prompt": "markdown"
+  },
+  // textlint
+  "textlint.configPath": "./configs/textlintrc.yaml"
+}

--- a/configs/.markdownlint-cli2.yaml
+++ b/configs/.markdownlint-cli2.yaml
@@ -8,8 +8,6 @@
 
 ## Files
 globs:
-  - "**/*.md"
-  - "**/*.prompt"
 
 ## Ignores
 # ignore gitignore

--- a/configs/textlintrc.yaml
+++ b/configs/textlintrc.yaml
@@ -36,6 +36,12 @@ rules:
       space:
         - alphabets
         - numbers
+    ja-space-around-code:
+      before: true
+      after: true
+    ja-space-around-link:
+      before: true
+      after: true
   common-misspellings: true
   no-mixed-zenkaku-and-hankaku-alphabet: true
   "@proofdict/proofdict":

--- a/dsl/llm-control-language-spec-compact.md
+++ b/dsl/llm-control-language-spec-compact.md
@@ -49,13 +49,13 @@ meta-block = "BEGIN" block-type "DEF" <opaque> "END" "DEF"
 block-type = DSL / MACRO / RULE / INPUT / OUTPUT
 ```
 
-**設計原則**:
+設計原則:
 
-1. **列挙しない**: コマンド名・変数名を列挙せず、形式だけ示す
-2. **body 定義しない**: `<opaque>` で内部構造隠蔽、中身に口出さない
-3. **分岐条件のみ残す**: 拡張ポイント (target) 明示で言語重心を示す
+1. 列挙しない: コマンド名・変数名を列挙せず、形式だけ示す
+2. body 定義しない: `<opaque>` で内部構造隠蔽、中身に口出さない
+3. 分岐条件のみ残す: 拡張ポイント (target) 明示で言語重心を示す
 
-**NOTE**: `<opaque>` =「この領域は LLM の自然言語理解に委ねる」。Backbone BNF は LLM との概念共有用、パーサー生成用ではない。
+NOTE: `<opaque>` =「この領域は LLM の自然言語理解に委ねる」。Backbone BNF は LLM との概念共有用、パーサー生成用ではない。
 
 ### 0.2 最小使用例
 
@@ -80,7 +80,7 @@ END INPUT
   根拠: 技術文書では明瞭さが重要です
 ```
 
-**NOTE**: 最小構成は `BEGIN INPUT` → コマンド実行 → `OUTPUT` の 3 ステップ。各詳細は後続セクションで定義。
+NOTE: 最小構成は `BEGIN INPUT` → コマンド実行 → `OUTPUT` の 3 ステップ。各詳細は後続セクションで定義。
 
 ---
 
@@ -149,14 +149,14 @@ payload     = field ":" type-name *("," field ":" type-name)
 field       = 1*(ALPHA / DIGIT / "_")
 ```
 
-**NOTE**:
+NOTE:
 
-- ABNF 形式により BNF から **60% 圧縮** (構造的明瞭性維持)
+- ABNF 形式により BNF から 60% 圧縮 (構造的明瞭性維持)
 - `ALPHA`, `DIGIT`, `VCHAR`, `DQUOTE` は RFC 5234 定義基本要素
 - chain (`->`) は 2-3 個推奨、120 文字制限厳守
 - 詳細構文 (phase-table, valid-table 等) は Section 2 以降に委譲
 
-**CONSTRAINT**:
+CONSTRAINT:
 
 - ABNF は意味的完全性持つ最小規則セット
 - 拡張構文は Extension セクション集約
@@ -174,7 +174,7 @@ field       = 1*(ALPHA / DIGIT / "_")
 | INPUT      | 型定義記述       | 構文解析段階            | 入力変数のスキーマ定義    |
 | OUTPUT     | 出力形式定義記述 | 構文解析段階            | OUTPUT 構造のスキーマ定義 |
 
-**NOTE**: DSL = 構文的除外 (コメント扱い) | MACRO/RULE/INPUT/OUTPUT = 解釈層での除外。メタブロックは実行フローに影響しない。
+NOTE: DSL = 構文的除外 (コメント扱い) | MACRO/RULE/INPUT/OUTPUT = 解釈層での除外。メタブロックは実行フローに影響しない。
 
 ---
 
@@ -203,7 +203,7 @@ alias-resolve:
   THEN command := alias-map[command]
 ```
 
-**エイリアス機構**:
+エイリアス機構:
 
 | 機構     | 説明                               | 例                 |
 | -------- | ---------------------------------- | ------------------ |
@@ -212,9 +212,9 @@ alias-resolve:
 | 効果範囲 | すべてのコマンド動作（完全一致）   | ACCEPTANCE遷移含む |
 | 宣言方法 | プロンプト固有定義セクションで列挙 | Section 6.3など    |
 
-**NOTE**: エイリアスは評価前に正規化され、意味論的差異・副作用の違いは存在しない。エイリアス解決後は元のコマンドと完全一致する動作となる。
+NOTE: エイリアスは評価前に正規化され、意味論的差異・副作用の違いは存在しない。エイリアス解決後は元のコマンドと完全一致する動作となる。
 
-**CONSTRAINT**: エイリアスは構文拡張ではなく、意味論層での正規化。ABNF 定義の変更は不要（`token = 1*(ALPHA / DIGIT / "-" / "_")` ですでにカバー済み）。
+CONSTRAINT: エイリアスは構文拡張ではなく、意味論層での正規化。ABNF 定義の変更は不要（`token = 1*(ALPHA / DIGIT / "-" / "_")` ですでにカバー済み）。
 
 ### 2.3 NOTE意味論
 
@@ -232,15 +232,14 @@ note-format    ::= 単一段落 | 複数段落(サブトピック区切り)
 | 用途       | 人間向け説明のみ                  |
 | CONSTRAINT | NOTE根拠の挙動変更=未定義動作     |
 | スコープ   | 直前要素補足 or 後続要素前提説明  |
-| 複数段落   | サブトピック区切り(`              |
 
-**NOTE 用途分類**:
+NOTE 用途分類:
 
-1. **説明的 NOTE**: 補足説明のみ (評価に影響なし)
-2. **制約的 NOTE**: CONSTRAINT の補足 (単独評価なし)
-3. **例示的 NOTE**: 使用例・デバッグ情報
+1. 説明的 NOTE: 補足説明のみ (評価に影響なし)
+2. 制約的 NOTE: CONSTRAINT の補足 (単独評価なし)
+3. 例示的 NOTE: 使用例・デバッグ情報
 
-**CONSTRAINT**: NOTE 単独で制約判断に使用禁止。ACCEPTANCE 遷移・COMMAND 可否判断に NOTE 内容使用禁止。解釈ロジックから分離。
+CONSTRAINT: NOTE 単独で制約判断に使用禁止。ACCEPTANCE 遷移・COMMAND 可否判断に NOTE 内容使用禁止。解釈ロジックから分離。
 
 ### 2.4 モード遷移
 
@@ -250,7 +249,7 @@ EXECUTE_MODE ::= idle | processing             ; 初期=idle
 generation-status ::= DRAFT | INCOMPLETE | READY ; 初期=DRAFT
 ```
 
-**ACCEPTANCE PRINCIPLE** (主導権原則):
+ACCEPTANCE PRINCIPLE (主導権原則):
 
 | 原則                       | 意味                                         |
 | -------------------------- | -------------------------------------------- |
@@ -262,9 +261,9 @@ generation-status ::= DRAFT | INCOMPLETE | READY ; 初期=DRAFT
 | 制御ではなく主導権の宣言   | LLM の自発的動作は主導権侵害                 |
 | すべて明示的コマンド開始   | 自発的処理の開始禁止                         |
 
-**CONSTRAINT**: ACCEPTANCE は「制御」でなく「主導権の宣言」。LLM の自発的動作=主導権侵害。処理は明示的コマンドのみで開始。
+CONSTRAINT: ACCEPTANCE は「制御」でなく「主導権の宣言」。LLM の自発的動作=主導権侵害。処理は明示的コマンドのみで開始。
 
-**層分離原則**:
+層分離原則:
 
 | レイヤー     | 変数              | スコープ             | 遷移条件                 | 責務           |
 | ------------ | ----------------- | -------------------- | ------------------------ | -------------- |
@@ -272,9 +271,9 @@ generation-status ::= DRAFT | INCOMPLETE | READY ; 初期=DRAFT
 | 処理層       | EXECUTE_MODE      | idle/processing      | SESSION_PHASE=reviewとき | 処理実行制御   |
 | 成果物準備層 | generation-status | DRAFT/INCOMPLETE/... | 情報充足判定             | OUTPUT生成可否 |
 
-**NOTE**: SESSION_PHASE (UI 層) | EXECUTE_MODE (処理層) | generation-status (成果物準備層) は独立。EXECUTE_MODE は SESSION_PHASE=review 時のみ遷移可能。
+NOTE: SESSION_PHASE (UI 層) | EXECUTE_MODE (処理層) | generation-status (成果物準備層) は独立。EXECUTE_MODE は SESSION_PHASE=review 時のみ遷移可能。
 
-**遷移規則**:
+遷移規則:
 
 | モード       | 許可遷移                     | 禁止遷移                            | 条件                    |
 | ------------ | ---------------------------- | ----------------------------------- | ----------------------- |
@@ -295,7 +294,7 @@ generation-status ::= DRAFT | INCOMPLETE | READY ; 初期=DRAFT
 | generation-status | DRAFT      | 情報不足検出 | INCOMPLETE | §2.12  |
 | generation-status | DRAFT      | 生成完了     | READY      | §2.12  |
 
-**NOTE**: 各モードの詳細は定義元セクション参照。
+NOTE: 各モードの詳細は定義元セクション参照。
 
 ### 2.5 コマンド制約
 
@@ -376,7 +375,7 @@ NOTE: PRIORITY = OUTPUT 生成時の優先度表示・複数指摘競合時の�
 
 NOTE: 未完成=TODO/メモ/箇条のみ検出時。エラー時=SESSION/REVIEW 変数保持。
 
-**NOTE**: 2.11 = 実行時エラー処理 | 2.12 = 事前検証ステータス。INCOMPLETE は generation-status (§2.12)、情報不足は処理エラー (§2.11)。
+NOTE: 2.11 = 実行時エラー処理 | 2.12 = 事前検証ステータス。INCOMPLETE は generation-status (§2.12)、情報不足は処理エラー (§2.11)。
 
 ### 2.12 記事生成ステータス
 
@@ -386,7 +385,7 @@ NOTE: 未完成=TODO/メモ/箇条のみ検出時。エラー時=SESSION/REVIEW 
 | INCOMPLETE | 情報不足     | 必須情報欠落 |
 | READY      | 生成完了     | 記事生成完了 |
 
-**meta_state 協調** (判別共用体制御):
+meta_state 協調 (判別共用体制御):
 
 | meta_state | generation-status | OUTPUT variant | 使用ケース     |
 | ---------- | ----------------- | -------------- | -------------- |
@@ -395,7 +394,7 @@ NOTE: 未完成=TODO/メモ/箇条のみ検出時。エラー時=SESSION/REVIEW 
 | generated  | READY             | ReviewResult   | 正常レビュー   |
 | generated  | READY             | ErrorResult    | 処理エラー     |
 
-**遷移規則**:
+遷移規則:
 
 | 遷移             | トリガー     | 効果                       |
 | ---------------- | ------------ | -------------------------- |
@@ -403,14 +402,14 @@ NOTE: 未完成=TODO/メモ/箇条のみ検出時。エラー時=SESSION/REVIEW 
 | DRAFT→READY      | 生成完了     | OUTPUT許可                 |
 | INCOMPLETE→input | 再入力要求   | 追加情報入力               |
 
-**CONSTRAINT**:
+CONSTRAINT:
 
 - OUTPUT は generation-status=READY かつ meta_state=generated/rejected の場合のみ生成
 - generation-status=INCOMPLETE 時は OUTPUT 生成禁止、ACCEPTANCE=PENDING 遷移促進
 - meta_state は OUTPUT 判別共用体の discriminator として機能
 - generation-status は宣言的制約 (実行ディレクティブでない)
 
-**NOTE**: generation-status vs ACCEPTANCE 分離 - ACCEPTANCE=UI 層 | generation-status=成果物準備層。EXECUTE_MODE(処理層)とも独立。
+NOTE: generation-status vs ACCEPTANCE 分離 - ACCEPTANCE=UI 層 | generation-status=成果物準備層。EXECUTE_MODE(処理層)とも独立。
 
 ### 2.13 フォールバック規則
 
@@ -424,7 +423,7 @@ LLM が仕様を守らない場合の縮退動作を定義します。
 | パラメータ欠落     | デフォルト値使用（全セクション対象） | 現状維持           |
 | コマンド構文エラー | エラー通知 → `/begin` 再入力促進     | ACCEPTANCE=PENDING |
 
-**フォールバック例**:
+フォールバック例:
 
 <!-- cspell:words reviw -->
 
@@ -433,7 +432,7 @@ LLM が仕様を守らない場合の縮退動作を定義します。
 /review Secton1   → Section1 を全セクション対象として処理
 ```
 
-**NOTE**: 縮退時は警告メッセージ出力。ユーザー修正を促すが処理は継続。
+NOTE: 縮退時は警告メッセージ出力。ユーザー修正を促すが処理は継続。
 
 #### 変数解決失敗時
 
@@ -443,14 +442,14 @@ LLM が仕様を守らない場合の縮退動作を定義します。
 | 変数型不一致 | 文字列として扱う               | 型変換試行             |
 | スコープ違反 | SESSION スコープで再検索       | 最大スコープにフォール |
 
-**フォールバック例**:
+フォールバック例:
 
-```COBOL
+```bash
 :undefined_var  → "[UNRESOLVED:undefined_var]"
 :buffer (未設定) → "[UNRESOLVED:buffer] (入力なし)"
 ```
 
-**NOTE**: `[UNRESOLVED:*]` マーカーは OUTPUT に含まれる。デバッグ・診断用途。
+NOTE: `[UNRESOLVED:*]` マーカーは OUTPUT に含まれる。デバッグ・診断用途。
 
 #### 状態遷移違反時
 
@@ -460,7 +459,7 @@ LLM が仕様を守らない場合の縮退動作を定義します。
 | EXEC_MODE 再入      | 実行拒否 → エラー通知         | 現状維持        |
 | 禁止遷移試行        | 遷移キャンセル → 警告出力     | 現状維持        |
 
-**NOTE**: 状態遷移違反は重大エラー。処理中断し、ユーザー介入を要求。
+NOTE: 状態遷移違反は重大エラー。処理中断し、ユーザー介入を要求。
 
 #### OUTPUT 生成失敗時
 
@@ -470,7 +469,7 @@ LLM が仕様を守らない場合の縮退動作を定義します。
 | CATEGORY 判定不能            | `[CATEGORY:unknown]` 付与、PRIORITY=B | デフォルト分類使用  |
 | PRIORITY 算出失敗            | PRIORITY=B (中優先度)                 | 保守的優先度設定    |
 
-**NOTE**: 判定不能時は保守的設定（PRIORITY=B）を採用。過小評価より過大評価を優先。
+NOTE: 判定不能時は保守的設定（PRIORITY=B）を採用。過小評価より過大評価を優先。
 
 #### 制約違反時の処理順序
 
@@ -479,9 +478,9 @@ LLM が仕様を守らない場合の縮退動作を定義します。
 3. フォールバック規則適用
 4. 保守的設定採用
 
-**CONSTRAINT**: フォールバック規則適用時も `:remark` > システムデフォルトの優先順位を維持。
+CONSTRAINT: フォールバック規則適用時も `:remark` > システムデフォルトの優先順位を維持。
 
-**NOTE**: フォールバック規則は本セクションで一度のみ定義。
+NOTE: フォールバック規則は本セクションで一度のみ定義。
 
 ---
 
@@ -498,7 +497,7 @@ PHILOSOPHY REVIEW:
   VIOLATION: STYLE_OVERRIDE→D | INTENT_DISREGARD→D+CONFIRM | SUBJECTIVE_BIAS→E | SCOPE_EXCESS→D
 ```
 
-**介入レベル判定**:
+介入レベル判定:
 
 | レベル | 判定条件         | 根拠要件               | PRIORITY |
 | ------ | ---------------- | ---------------------- | -------- |
@@ -511,13 +510,13 @@ PHILOSOPHY REVIEW:
 ```abnf
 RULE FAIL_FAST:
   IF structural_collapse → INCOMPLETE + "構造崩壊"
-  IF technical_fatality → SKIP + "技術的致命傷"
+  IF technical_fatality → INCOMPLETE + "技術的致命傷"
   IF unreadability → INCOMPLETE + "可読性未確立"
   IF insufficient_length → INCOMPLETE + "文章量不足"
   IF incomplete_content → INCOMPLETE + "未完成"
 ```
 
-**判定基準 (形式化・検出方法)**:
+判定基準 (形式化・検出方法):
 
 | 条件                | 検出方法                                          | 閾値                   | 根拠             |
 | ------------------- | ------------------------------------------------- | ---------------------- | ---------------- |
@@ -527,7 +526,7 @@ RULE FAIL_FAST:
 | insufficient_length | Unicode文字数 (コードブロック除外)                | <500文字               | レビュー対象不足 |
 | incomplete_content  | TODO/TBDマーカー: `/TODO\|FIXME\|TBD\|WIP/`, 箇条 | ≥1個 OR 比率>30%       | 未完成           |
 
-**NOTE**: 閾値はヒューリスティック。建設的な再提出ガイド必須。拒否=「前提条件未達」(「改善余地なし」でない)。
+NOTE: 閾値はヒューリスティック。建設的な再提出ガイド必須。拒否=「前提条件未達」(「改善余地なし」でない)。
 
 ### 3.3 Priority Conversion
 
@@ -545,31 +544,31 @@ VIOLATION降格 (enum定義: §4.6):
   SCOPE_EXCESS → force D
 ```
 
-**優先順位**: `:remark` > VIOLATION 降格 > CATEGORY 写像 > デフォルト。
+優先順位: `:remark` > VIOLATION 降格 > CATEGORY 写像 > デフォルト。
 
 ### 3.4 制約規則統合
 
-**Philosophy enforcement**:
+Philosophy enforcement:
 
 - 違反ラベル付き指摘は自動降格
 - LLM は違反を自己検出し、違反に応じたラベルの付与が必須
 - レビュー出力は哲学原則に従う
 - `:remark` で明示的に指定された場合のみ例外を許可
 
-**ACCEPTANCE principle** (**→ See Section 2.3 for full ACCEPTANCE definition**):
+ACCEPTANCE principle: See §2.4 for full ACCEPTANCE definition.
 
-**Fail-fast constraints**:
+Fail-fast constraints:
 
 - 建設的な再提出ガイドを必ず提供
 - レビュー拒否は「レビュー前提条件未達」を意味する (「改善の余地なし」ではない)
 
-**Output generation guard**:
+Output generation guard:
 
 - OUTPUT は generation-status=READY かつ meta_state=generated/rejected の場合のみ生成
 - INCOMPLETE 状態は OUTPUT 生成禁止、ACCEPTANCE=PENDING 遷移促進
 - 生成系プロンプトで適用、レビュー系では不要
 
-**Enum constraints**:
+Enum constraints:
 
 - CATEGORY/PRIORITY の enum 拡張は禁止 (closed: true)
 - VIOLATION/STATUS の enum 拡張は禁止 (closed: true)
@@ -578,7 +577,7 @@ VIOLATION降格 (enum定義: §4.6):
 - 同一指摘に VIOLATION+STATUS の両方付与可能、効果は累積
 - `unknown` カテゴリは判定不能時のフォールバック専用、通常使用禁止
 
-**Override mechanism**:
+Override mechanism:
 
 - `:remark` はすべての規則を上書き可能
 - フォールバック規則適用時も `:remark` > システムデフォルト
@@ -945,7 +944,7 @@ PRIORITY: C
 VIOLATION: STYLE_OVERRIDE
 ```
 
-**NOTE**:
+NOTE:
 
 - フィールド順序は厳密に 1→9 の順 (上記スキーマの output_order に従う)
 - 指摘間の区切りは `\n---\n` (3行：空行、ハイフン 3つ、空行)
@@ -1004,7 +1003,7 @@ CATEGORY:
 | readability   | 可読性     | C                           | 冗長表現、構造改善            |
 | unknown       | 判定不能   | B (保守的設定)              | フォールバック専用            |
 
-**CONSTRAINT**:
+CONSTRAINT:
 
 - CATEGORY/PRIORITY の enum 拡張は禁止 (closed: true)
 - CATEGORY→PRIORITY 写像は `:remark` で上書き可能
@@ -1047,14 +1046,14 @@ STATUS:
 | STATUS: QUESTION_REQUIRED    | 状態   | 追加情報要求、レビュー保留 | -        | 意図不明とき               |
 | STATUS: CLARIFICATION_NEEDED | 状態   | 明確化要求、レビュー保留   | -        | 情報不足時                 |
 
-**CONSTRAINT**:
+CONSTRAINT:
 
 - VIOLATION/STATUS の enum 拡張は禁止 (closed: true)
 - VIOLATION 付き指摘は自動的に PRIORITY 降格 (side_effects 定義に従う)
 - STATUS 付き指摘はレビュー保留状態、ユーザー応答待機
 - 同一指摘に VIOLATION+STATUS の両方付与可能、効果は累積
 
-**CONSTRAINT OUTPUT generation guard**:
+CONSTRAINT OUTPUT generation guard:
 
 - OUTPUT は generation-status=READY かつ meta_state=generated/rejected の場合のみ生成
 - generation-status=INCOMPLETE 時は OUTPUT 生成禁止、ACCEPTANCE=PENDING 遷移促進
@@ -1130,13 +1129,13 @@ EXECUTE 文は操作的ディレクティブ (operational directive) であり�
 | flow_control_leak | EXECUTE で通常フロー制御を迂回 | COMMAND による明示的制御     | EXECUTE は例外処理のみ、通常フローは COMMAND |
 | execution_assumed | Appendix 記載=実行と誤解       | 「参照のみ・実行禁止」を明記 | EXECUTE は列挙手順のみ (実行は LLM 判断)     |
 
-**CONSTRAINT**:
+CONSTRAINT:
 
 - EXECUTE 文内での ACCEPTANCE 遷移は禁止 (明示的 SET で記述)
 - EXECUTE は宣言的記述、LLM への指針提供が目的 (強制実行ではない)
 - EXECUTE 文は Appendix の手順を「参照」、自動実行は行わない
 
-**NOTE**: EXECUTE 文の過剰使用は DSL の宣言的性質を損なう。通常フロー制御は COMMAND/EVENT で表現。
+NOTE: EXECUTE 文の過剰使用は DSL の宣言的性質を損なう。通常フロー制御は COMMAND/EVENT で表現。
 
 ### 5.4 出力CONSTRAINT
 
@@ -1170,20 +1169,20 @@ EVENT handler は異常系復旧専用であり、通常フロー制御に使用
 | implicit_state_change | 状態変更の暗黙化             | SET 文による明示的状態変更              |
 | handler_chaining      | handler 連鎖によるフロー構築 | COMMAND 連鎖                            |
 
-**許可用途** (復旧のみ):
+許可用途 (復旧のみ):
 
 | 許可パターン             | 用途                       | 例                                               |
 | ------------------------ | -------------------------- | ------------------------------------------------ |
 | abnormal_termination_rec | 異常終了からの復旧         | `ON ProcessFailed DO SET ACCEPTANCE=PENDING END` |
 | error_rollback           | エラー時の状態ロールバック | `ON ValidationError DO CLEAR :buffer END`        |
 
-**CONSTRAINT**:
+CONSTRAINT:
 
 - EVENT handler 内での SESSION_PHASE 遷移は復旧目的のみ許可
 - 通常フロー制御・条件分岐・遷移規則迂回は COMMAND で表現
 - EVENT は「通知」、handler は「復旧」のみの責務
 
-**NOTE**: EVENT handler の過剰使用は DSL の宣言的性質を損なう。通常フロー制御は COMMAND で明示的に表現。
+NOTE: EVENT handler の過剰使用は DSL の宣言的性質を損なう。通常フロー制御は COMMAND で明示的に表現。
 
 ---
 

--- a/dsl/llm-control-language-spec.md
+++ b/dsl/llm-control-language-spec.md
@@ -16,10 +16,10 @@ architecture: 5-layer (Part 0:Overview / Part 1:Syntax / Part 2:Semantics / Part
 
 **設計原則**:
 
-1. **統一形式**: `DEF ... THEN ... END` (すべてのマクロ)
-2. **四層構造**: Syntax (BNF 文法) / Semantics (形式意味論) / Common Macros (標準実装) / Heuristics (スタイル指針)
-3. **識別子**: ASCII 限定(`<ascii-id>`) / 日本語許可(`<label>`)
-4. **自己記述**: Part 2/3 は Part 1 のマクロ構文で意味論と実装を定義
+1. 統一形式: `DEF ... THEN ... END` (すべてのマクロ)
+2. 四層構造: Syntax (BNF 文法) / Semantics (形式意味論) / Common Macros (標準実装) / Heuristics (スタイル指針)
+3. 識別子: ASCII 限定(`<ascii-id>`) / 日本語許可(`<label>`)
+4. 自己記述: Part 2/3 は Part 1 のマクロ構文で意味論と実装を定義
 
 **NOTE**: 本 DSL は実行を目的としない。LLM との認識共有を目的とする。
 
@@ -61,9 +61,9 @@ block-type = DSL / MACRO / RULE / INPUT / OUTPUT
 
 **Backbone BNF の設計原則**:
 
-1. **列挙しない**: コマンド名や変数名を列挙せず、形式だけ示す (例: `command = "/" identifier`)
-2. **body を定義しない**: `<opaque>` で内部構造を隠蔽し、中身に口を出さない
-3. **分岐条件だけ残す**: 拡張ポイント (target) は明示し、言語の重心を示す
+1. 列挙しない: コマンド名や変数名を列挙せず、形式だけ示す (例: `command = "/" identifier`)
+2. body を定義しない: `<opaque>` で内部構造を隠蔽し、中身に口を出さない
+3. 分岐条件だけ残す: 拡張ポイント (target) は明示し、言語の重心を示す
 
 **NOTE: Backbone BNF の不変性宣言**:
 
@@ -92,7 +92,7 @@ Backbone BNF は「姿勢定義」であり、次のような目的はありま�
 ; Fail-fast: 5条件 (構造崩壊、技術的致命性、読解不能、文字数不足、未完成)
 ```
 
-詳細は[3.1 Review Philosophy](#31-review-philosophy)、[3.4 制約規則統合](#34-制約規則統合)を参照してください。
+詳細は [3.1 Review Philosophy](#31-review-philosophy)、[3.4 制約規則統合](#34-制約規則統合) を参照してください。
 
 ## 目次
 
@@ -137,6 +137,7 @@ Backbone BNF は「姿勢定義」であり、次のような目的はありま�
   - [3.2 Fail-Fast Policy](#32-fail-fast-policy)
   - [3.3 Priority Conversion](#33-priority-conversion)
   - [3.4 制約規則統合](#34-制約規則統合)
+  - [3.5 Proposal Generation Policy](#35-proposal-generation-policy)
 - [Part 4: Common Macros (標準実装)](#part-4-common-macros-標準実装)
   - [共通モード構造](#共通モード構造)
   - [入力セクション構造](#入力セクション構造)
@@ -148,6 +149,7 @@ Backbone BNF は「姿勢定義」であり、次のような目的はありま�
   - [OUTPUT Structure Extension AS "出力構造化の拡張"](#output-structure-extension-as-出力構造化の拡張)
     - [Simple Definition to Detailed Schema Correspondence AS "簡易定義と詳細スキーマの対応関係"](#simple-definition-to-detailed-schema-correspondence-as-簡易定義と詳細スキーマの対応関係)
     - [OUTPUT Format Schema AS "OUTPUT形式スキーマ (厳密定義)"](#output-format-schema-as-output形式スキーマ-厳密定義)
+    - [Proposal Format Schema](#proposal-format-schema)
     - [Schema Validation Rules AS "スキーマ検証ルール"](#schema-validation-rules-as-スキーマ検証ルール)
     - [Output Format Example AS "出力形式例 (スキーマ準拠)"](#output-format-example-as-出力形式例-スキーマ準拠)
     - [OUTPUT Definition Cross-Reference AS "OUTPUT定義のクロスリファレンス"](#output-definition-cross-reference-as-output定義のクロスリファレンス)
@@ -411,10 +413,10 @@ END DEF
 
 **重要な特性**:
 
-1. **構文的除外**: BEGIN...END DEF 内は LLM の校閲・レビュー処理から**除外**
-2. **定義登録**: 内容は「定義」として登録・解釈されるが、**文章としては評価されない**
-3. **指摘禁止**: 誤字脱字・曖昧表現を含め**一切の指摘を禁止**
-4. **スコープ**: ブロック外の Markdown 説明文のみが校閲対象
+1. 構文的除外: BEGIN...END DEF 内は LLM の校閲・レビュー処理から除外
+2. 定義登録: 内容は「定義」として登録・解釈されるが、文章としては評価されない
+3. 指摘禁止: 誤字脱字・曖昧表現を含め一切の指摘を禁止
+4. スコープ: ブロック外の Markdown 説明文のみが校閲対象
 
 **RULE との違い**:
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "format:prompts": "bash ./scripts/prompt-formatter.sh",
     "check:spells": "pnpm exec cspell  --config .vscode/cspell.json --cache --cache-location .cache/cspell/cSpellCache",
     "lint:text": "textlint --config ./configs/textlintrc.yaml --cache --cache-location .cache/textlint-cache/textlintCache ",
-    "lint:markdown": "pnpm exec markdownlint-cli2 --config ./configs/.markdownlint-cli2.yaml ",
+    "lint:prompt": "markdownlint --config ./configs/.markdownlint-cli2.yaml **/*.prompt",
+    "lint:markdown": "markdownlint --config ./configs/.markdownlint-cli2.yaml **/*.md",
     "lint:filename": "pnpm exec ls-lint --config ./configs/ls-lint.yaml ",
     "lint:secrets": "secretlint --secretlintrc ./configs/secretlint.config.yaml --secretlintignore .gitignore --maskSecrets **/*"
   }

--- a/tech-articles-prompt/article-proofreading.prompt
+++ b/tech-articles-prompt/article-proofreading.prompt
@@ -12,6 +12,8 @@ meta:
     - Copyright (c) 2025 atsushifx <https://github.com/atsushifx/>
 ---
 
+<!-- markdownlint-disable line-length -->
+
 ## Overview (概要)
 
 **目的**: 技術ブログ記事における読みにくさ・不正確さ・表記揺れを指摘し、改善案を提示する校閲プロンプト
@@ -85,7 +87,7 @@ block-type = DSL / MACRO / RULE / INPUT / OUTPUT
 
 本 DSL の基本パターンを示します。
 
-```
+```text
 BEGIN INPUT
   SET :buffer = """
 技術記事の内容をここに記述します。
@@ -213,8 +215,8 @@ field       = 1*(ALPHA / DIGIT / "_")
 構文解析 → 意味論評価 → 実行
 ```
 
-| レイヤー | 役割                       |
-| -------- | -------------------------- |
+| レイヤー | 役割                        |
+| -------- | --------------------------- |
 | 構文     | 文法的正当性 (パース可能性) |
 | 意味論   | 実行時意味 (制約・状態遷移) |
 
@@ -263,31 +265,32 @@ EXECUTE_MODE ::= idle | processing             ; 初期=idle
 
 **層分離原則**:
 
-| レイヤー | 変数       | スコープ             | 遷移条件               | 責務           |
-| -------- | ---------- | -------------------- | ---------------------- | -------------- |
-| UI 層    | SESSION_PHASE | command/input/review | /begin, /end, /exit    | ユーザー対話   |
-| 処理層   | EXECUTE_MODE | idle/processing      | SESSION_PHASE=review時 | 処理実行制御   |
+| レイヤー | 変数          | スコープ             | 遷移条件               | 責務         |
+| -------- | ------------- | -------------------- | ---------------------- | ------------ |
+| UI 層    | SESSION_PHASE | command/input/review | /begin, /end, /exit    | ユーザー対話 |
+| 処理層   | EXECUTE_MODE  | idle/processing      | SESSION_PHASE=review時 | 処理実行制御 |
 
-**NOTE**: SESSION_PHASE (UI 層) | EXECUTE_MODE (処理層) は独立。EXECUTE_MODE は SESSION_PHASE=review 時のみ遷移可能。校閲系では generation-status 不要。
+**NOTE**:
+SESSION_PHASE (UI 層) | EXECUTE_MODE (処理層) は独立。EXECUTE_MODE は SESSION_PHASE=review 時のみ遷移可能。校閲系では generation-status 不要。
 
 **遷移規則**:
 
-| モード       | 許可遷移                 | 禁止遷移                          | 条件            |
-| ------------ | ------------------------ | --------------------------------- | --------------- |
-| ACCEPTANCE   | PENDING→ACTIVE(一時)→PENDING | 自動遷移禁止                      | /review のみ    |
-| EXECUTE_MODE | idle→proc→idle           | proc→proc                         | ACCEPTANCE=ACTIVE時のみ |
-| 出力制約     | processing時=事実通知のみ | processing時=説明文・考察・推論禁止 | -               |
+| モード       | 許可遷移                     | 禁止遷移                            | 条件                    |
+| ------------ | ---------------------------- | ----------------------------------- | ----------------------- |
+| ACCEPTANCE   | PENDING→ACTIVE(一時)→PENDING | 自動遷移禁止                        | /review のみ            |
+| EXECUTE_MODE | idle→proc→idle               | proc→proc                           | ACCEPTANCE=ACTIVE時のみ |
+| 出力制約     | processing時=事実通知のみ    | processing時=説明文・考察・推論禁止 | -                       |
 
 ### 2.4 コマンド制約
 
-| コマンド | 実行ACCEPTANCE     | 副作用                                      | 再入 |
-| -------- | ------------------ | ------------------------------------------- | ---- |
-| /begin   | PENDING            | CLEAR :buffer                               | 可   |
-| /review  | PENDING→ACTIVE(一時) | EXEC_MODE: idle→proc→idle                   | 禁止 |
-| /write   | PENDING→ACTIVE(一時) | EXEC_MODE: idle→proc→idle                   | 禁止 |
-| /exit    | *                  | CLEAR ALL, EXEC_MODE=idle                   | -    |
-| /reset   | *                  | CLEAR :var.. (スコープ内のみ)                | -    |
-| /set     | *                  | SET :var=value (スコープ内上書き許可)        | -    |
+| コマンド | 実行ACCEPTANCE       | 副作用                                | 再入 |
+| -------- | -------------------- | ------------------------------------- | ---- |
+| /begin   | PENDING              | CLEAR :buffer                         | 可   |
+| /review  | PENDING→ACTIVE(一時) | EXEC_MODE: idle→proc→idle             | 禁止 |
+| /write   | PENDING→ACTIVE(一時) | EXEC_MODE: idle→proc→idle             | 禁止 |
+| /exit    | *                    | CLEAR ALL, EXEC_MODE=idle             | -    |
+| /reset   | *                    | CLEAR :var.. (スコープ内のみ)         | -    |
+| /set     | *                    | SET :var=value (スコープ内上書き許可) | -    |
 
 **NOTE**: /review, /write = EXEC_MODE遷移必須、再入禁止。ACCEPTANCE=* はすべての状態で実行可能。
 
@@ -302,14 +305,14 @@ EXECUTE_MODE ::= idle | processing             ; 初期=idle
 
 ### 2.6 実行規約
 
-| 項目      | 規則                                      |
-| --------- | ----------------------------------------- |
-| 評価順序  | DEF順・上から下                           |
-| 再定義    | 禁止                                      |
-| VAR       | 暗黙可変、初期値=空文字列                 |
-| EXECUTE   | 列挙手順のみ (Appendix参照のみ、実行禁止) |
-| 停止条件  | LLM判断依存、明示推奨                     |
-| アクション | CLEAR -> SET -> EXECUTE -> SET ACCEPTANCE       |
+| 項目       | 規則                                      |
+| ---------- | ----------------------------------------- |
+| 評価順序   | DEF順・上から下                           |
+| 再定義     | 禁止                                      |
+| VAR        | 暗黙可変、初期値=空文字列                 |
+| EXECUTE    | 列挙手順のみ (Appendix参照のみ、実行禁止) |
+| 停止条件   | LLM判断依存、明示推奨                     |
+| アクション | CLEAR -> SET -> EXECUTE -> SET ACCEPTANCE |
 
 **NOTE**: CLEAR ALL = 全スコープクリア。`DEF /begin THEN CLEAR :buffer END` (ACCEPTANCE状態不変)
 
@@ -335,12 +338,12 @@ EXECUTE_MODE ::= idle | processing             ; 初期=idle
 
 ### 2.9 CONSTRAINT
 
-| 要素        | 用途               | 禁止用途                     |
-| ----------- | ------------------ | ---------------------------- |
-| PRIORITY    | 衝突時選択指針     | 適用可否・評価順序制御       |
-| description | 説明文             | 判定・制御ロジック           |
-| label       | 表示名             | 識別子・検索キー             |
-| free-text   | 自由記述           | パース・構文解析             |
+| 要素        | 用途           | 禁止用途               |
+| ----------- | -------------- | ---------------------- |
+| PRIORITY    | 衝突時選択指針 | 適用可否・評価順序制御 |
+| description | 説明文         | 判定・制御ロジック     |
+| label       | 表示名         | 識別子・検索キー       |
+| free-text   | 自由記述       | パース・構文解析       |
 
 **NOTE**: PRIORITY = OUTPUT生成時の優先度表示・複数指摘競合時の重み付けのみ。
 
@@ -348,12 +351,12 @@ EXECUTE_MODE ::= idle | processing             ; 初期=idle
 
 #### 基本処理規則
 
-| 状況     | 処理                                       | ACCEPTANCE/EXEC     |
-| -------- | ------------------------------------------ | ------------------- |
-| 情報不足 | EMIT ProcessFailed -> Open Questions出力   | 現状維持            |
-| 判断不能 | CONSTRAINT確認 -> :remark優先 -> 保守選択  | 現状維持            |
-| 未完成   | 停止 -> /begin再入力促進                   | ACCEPTANCE=PENDING  |
-| 実行中断 | EXEC_MODE: proc->idle, ACCEPTANCE復帰      | SESSION保持         |
+| 状況     | 処理                                      | ACCEPTANCE/EXEC    |
+| -------- | ----------------------------------------- | ------------------ |
+| 情報不足 | EMIT ProcessFailed -> Open Questions出力  | 現状維持           |
+| 判断不能 | CONSTRAINT確認 -> :remark優先 -> 保守選択 | 現状維持           |
+| 未完成   | 停止 -> /begin再入力促進                  | ACCEPTANCE=PENDING |
+| 実行中断 | EXEC_MODE: proc->idle, ACCEPTANCE復帰     | SESSION保持        |
 
 NOTE: 未完成=TODO/メモ/箇条のみ検出時。エラー時=SESSION/REVIEW 変数保持。
 
@@ -410,19 +413,19 @@ NOTE: 未完成=TODO/メモ/箇条のみ検出時。エラー時=SESSION/REVIEW 
 
 ### 2.11 フォールバック規則
 
-| カテゴリ | 状況 | フォールバック動作 | ACCEPTANCE/EXEC |
-|---------|------|-------------------|-----------------|
-| **コマンド** | 不明/構文エラー | 基本モード縮退 → エラー通知 | ACCEPTANCE=PENDING |
-| | パラメータ欠落 | デフォルト値使用 (全セクション対象)  | 現状維持 |
-| **変数** | 未定義 | `[UNRESOLVED:変数名]` 付与 | - |
-| | 型不一致 | 文字列として扱う | - |
-| | スコープ違反 | SESSION スコープで再検索 | - |
-| **状態遷移** | ACCEPTANCE自動遷移 | PENDING に強制復帰 | SESSION保持 |
-| | EXEC_MODE再入 | 実行拒否 → エラー通知 | 現状維持 |
-| | 禁止遷移試行 | 遷移キャンセル → 警告 | 現状維持 |
-| **OUTPUT** | generation-status=INCOMPLETE | 生成スキップ → 情報不足通知 | Open Questions出力 |
-| | CATEGORY判定不能 | `[CATEGORY:unknown]` + PRIORITY=B | デフォルト分類 |
-| | PRIORITY算出失敗 | PRIORITY=B (保守的設定)  | - |
+| カテゴリ     | 状況                         | フォールバック動作                  | ACCEPTANCE/EXEC    |
+| ------------ | ---------------------------- | ----------------------------------- | ------------------ |
+| **コマンド** | 不明/構文エラー              | 基本モード縮退 → エラー通知         | ACCEPTANCE=PENDING |
+|              | パラメータ欠落               | デフォルト値使用 (全セクション対象) | 現状維持           |
+| **変数**     | 未定義                       | `[UNRESOLVED:変数名]` 付与          | -                  |
+|              | 型不一致                     | 文字列として扱う                    | -                  |
+|              | スコープ違反                 | SESSION スコープで再検索            | -                  |
+| **状態遷移** | ACCEPTANCE自動遷移           | PENDING に強制復帰                  | SESSION保持        |
+|              | EXEC_MODE再入                | 実行拒否 → エラー通知               | 現状維持           |
+|              | 禁止遷移試行                 | 遷移キャンセル → 警告               | 現状維持           |
+| **OUTPUT**   | generation-status=INCOMPLETE | 生成スキップ → 情報不足通知         | Open Questions出力 |
+|              | CATEGORY判定不能             | `[CATEGORY:unknown]` + PRIORITY=B   | デフォルト分類     |
+|              | PRIORITY算出失敗             | PRIORITY=B (保守的設定)             | -                  |
 
 **処理順序**: 1. CONSTRAINT確認 → 2. `:remark`優先適用 → 3. フォールバック規則 → 4. 保守的設定
 
@@ -445,11 +448,11 @@ PHILOSOPHY REVIEW:
 
 **介入レベル判定**:
 
-| レベル | 判定条件 | 根拠要件 | PRIORITY |
-|--------|---------|---------|----------|
-| HIGH | 技術的誤り検出 | :link検証済 OR 公式Doc | A |
-| MEDIUM | 論理的不整合検出 | 文書内複数箇所比較 | B |
-| LOW | 表現改善提案 | ベストプラクティス | C |
+| レベル | 判定条件         | 根拠要件               | PRIORITY |
+| ------ | ---------------- | ---------------------- | -------- |
+| HIGH   | 技術的誤り検出   | :link検証済 OR 公式Doc | A        |
+| MEDIUM | 論理的不整合検出 | 文書内複数箇所比較     | B        |
+| LOW    | 表現改善提案     | ベストプラクティス     | C        |
 
 **NOTE**: 主目的=技術的正確性・読みやすさ向上。高介入=技術的誤り (明示的+具体的代案) 。中介入=構造的問題・論理矛盾。低介入=表現最適化。許可変更=誤字脱字・文法・用語統一。禁止変更=技術的主張変更・設計全面書き換え・セクション削除。
 
@@ -468,9 +471,10 @@ RULE FAIL_FAST:
 
 **判定基準 (形式化・検出方法)**:
 
-| 条件                | 検出方法                                          | 閾値                   | 根拠             |
-| ------------------- | ------------------------------------------------- | ---------------------- | ---------------- |
-| structural_collapse | 見出し階層飛び: `^#{1,6}` regex, 必須section欠落  | gap>1 OR 概要/結論なし | 構造破綻         |
+| 条件                | 検出方法                                         | 閾値                   | 根拠     |
+| ------------------- | ------------------------------------------------ | ---------------------- | -------- |
+| structural_collapse | 見出し階層飛び: `^#{1,6}` regex, 必須section欠落 | gap>1 OR 概要/結論なし | 構造破綻 |
+
 | technical_fatality  | コードブロック未閉: `` ``` `` ペア不整合, API誤用 | unclosed>0 OR errors≥3 | 実行不可能       |
 | unreadability       | 主題文欠落率, 接続詞密度                          | 欠落率>50% OR 接続<10% | 意図伝達不可     |
 | insufficient_length | Unicode文字数 (コードブロック除外)                | <500文字               | レビュー対象不足 |
@@ -490,12 +494,12 @@ PRIORITY_CONVERSION:
 
 **CATEGORY → PRIORITY 写像**:
 
-| CATEGORY | デフォルトPRIORITY | :link有 | :linkなし | VIOLATION降格 |
-|----------|-------------------|---------|-----------|--------------|
-| inaccuracy | A / B | A | B | 違反時→D/E |
-| inconsistency | B | - | B | 違反時→D/E |
-| readability | C | - | C | 違反時→D/E |
-| unknown | B | - | B (保守的設定) | 違反時→D/E |
+| CATEGORY      | デフォルトPRIORITY | :link有 | :linkなし      | VIOLATION降格 |
+| ------------- | ------------------ | ------- | -------------- | ------------- |
+| inaccuracy    | A / B              | A       | B              | 違反時→D/E    |
+| inconsistency | B                  | -       | B              | 違反時→D/E    |
+| readability   | C                  | -       | C              | 違反時→D/E    |
+| unknown       | B                  | -       | B (保守的設定) | 違反時→D/E    |
 
 **優先順位**: `:remark` > VIOLATION降格 > CATEGORY写像 > デフォルト
 
@@ -553,35 +557,35 @@ END INPUT
 
 ### 4.2 標準コマンド
 
-| コマンド            | 動作                    | 値形式            |
-| ------------------- | ----------------------- | ----------------- |
-| /begin              | CLEAR :buffer           | -                 |
-| /end                | :buffer確定             | -                 |
-| /exit               | CLEAR ALL               | -                 |
-| /reset <:var..>     | CLEAR :var..            | -                 |
-| /set <:var>=<value> | SET :var=value          | "text"\|\|\|"""" |
+| コマンド                | 動作           | 値形式           |
+| ----------------------- | -------------- | ---------------- |
+| /begin                  | CLEAR :buffer  | -                |
+| /end                    | :buffer確定    | -                |
+| /exit                   | CLEAR ALL      | -                |
+| /reset <:var..>         | CLEAR :var..   | -                |
+| /set `<:var>`=`<value>` | SET :var=value | "text"\|\|\|"""" |
 
 **NOTE**: スコープ内上書き可。SESSION=/exit, REVIEW=/begin。
 
 ### 4.3 標準変数
 
-| 変数    | スコープ | 用途                             | クリア |
-| ------- | -------- | -------------------------------- | ------ |
-| :role   | SESSION  | ユーザー役割                     | /exit  |
-| :link   | SESSION  | 参考URL (文体抽象化、模倣禁止)   | /exit  |
-| :remark | SESSION  | 特記事項                         | /exit  |
-| :buffer | REVIEW   | 入力蓄積                         | /begin |
-| :review | REVIEW   | 処理結果                         | /begin |
+| 変数    | スコープ | 用途                           | クリア |
+| ------- | -------- | ------------------------------ | ------ |
+| :role   | SESSION  | ユーザー役割                   | /exit  |
+| :link   | SESSION  | 参考URL (文体抽象化、模倣禁止) | /exit  |
+| :remark | SESSION  | 特記事項                       | /exit  |
+| :buffer | REVIEW   | 入力蓄積                       | /begin |
+| :review | REVIEW   | 処理結果                       | /begin |
 
 ### 4.4 標準イベント
 
-| イベント           | タイミング | ペイロード                      |
-| ------------------ | ---------- | ------------------------------- |
-| ProcessStarted     | 開始       | command:text, mode:mode         |
-| ProcessInterrupted | 中断       | reason:text, previous_mode:mode |
-| ProcessCompleted   | 完了       | result:object                   |
-| ProcessFailed      | 失敗       | error:text                      |
-| ModeChanged        | ACCEPTANCE遷移   | from:mode, to:mode              |
+| イベント           | タイミング     | ペイロード                      |
+| ------------------ | -------------- | ------------------------------- |
+| ProcessStarted     | 開始           | command:text, mode:mode         |
+| ProcessInterrupted | 中断           | reason:text, previous_mode:mode |
+| ProcessCompleted   | 完了           | result:object                   |
+| ProcessFailed      | 失敗           | error:text                      |
+| ModeChanged        | ACCEPTANCE遷移 | from:mode, to:mode              |
 
 ### 4.5 文章位置定義
 
@@ -722,35 +726,37 @@ Finding:
   finding_separator: "\n---\n" # 指摘間区切り
 ```
 
-**CONSTRAINT**: フィールド順序厳守(1→9)。識別子=セッション内一意。VIOLATION付き=自動降格。enum拡張禁止(closed: true)。該当箇所=4.5で定義されたLOCATION形式。meta_state は discriminator として OUTPUT variant を決定。
+**CONSTRAINT**:
+フィールド順序厳守(1→9)。識別子=セッション内一意。VIOLATION付き=自動降格。enum拡張禁止(closed: true)。
+該当箇所=4.5で定義されたLOCATION形式。meta_state は discriminator として OUTPUT variant を決定。
 
 #### CATEGORY/PRIORITY定義
 
-| CATEGORY | 意味 | デフォルトPRIORITY | 使用条件 |
-|----------|------|-------------------|---------|
-| inaccuracy | 技術的誤り | A (:link有) / B (:linkなし) | 事実誤認、API誤用、コードバグ |
-| inconsistency | 不整合 | B | 用語不統一、論理矛盾 |
-| readability | 可読性 | C | 冗長表現、構造改善 |
-| unknown | 判定不能 | B (保守的設定)  | フォールバック専用 |
+| CATEGORY      | 意味       | デフォルトPRIORITY          | 使用条件                      |
+| ------------- | ---------- | --------------------------- | ----------------------------- |
+| inaccuracy    | 技術的誤り | A (:link有) / B (:linkなし) | 事実誤認、API誤用、コードバグ |
+| inconsistency | 不整合     | B                           | 用語不統一、論理矛盾          |
+| readability   | 可読性     | C                           | 冗長表現、構造改善            |
+| unknown       | 判定不能   | B (保守的設定)              | フォールバック専用            |
 
-| PRIORITY | 意味 | 用途 |
-|----------|------|------|
-| A | 最高優先度 (致命的)  | 技術的誤り (:link検証済み)  |
-| B | 高優先度 (重要)  | 構造的問題、不整合、技術的誤り (未検証)  |
-| C | 中優先度 (推奨)  | 可読性、表現改善 |
-| D | 低優先度 (任意)  | スタイル提案、哲学違反降格 |
-| E | 最低優先度 (情報)  | 参考情報、補足 |
+| PRIORITY | 意味                | 用途                                    |
+| -------- | ------------------- | --------------------------------------- |
+| A        | 最高優先度 (致命的) | 技術的誤り (:link検証済み)              |
+| B        | 高優先度 (重要)     | 構造的問題、不整合、技術的誤り (未検証) |
+| C        | 中優先度 (推奨)     | 可読性、表現改善                        |
+| D        | 低優先度 (任意)     | スタイル提案、哲学違反降格              |
+| E        | 最低優先度 (情報)   | 参考情報、補足                          |
 
 #### VIOLATION/STATUS定義
 
-| ラベル | タイプ | 効果 | PRIORITY |
-|--------|--------|------|----------|
-| VIOLATION: STYLE_OVERRIDE | 違反 | 指摘をDに降格 | D |
-| VIOLATION: INTENT_DISREGARD | 違反 | ユーザー確認要求 | D |
-| VIOLATION: SUBJECTIVE_BIAS | 違反 | 指摘をEに降格 | E |
-| VIOLATION: SCOPE_EXCESS | 違反 | 範囲逸脱通知 | D |
-| STATUS: QUESTION_REQUIRED | 状態 | レビュー保留 | - |
-| STATUS: CLARIFICATION_NEEDED | 状態 | 明確化要求 | - |
+| ラベル                       | タイプ | 効果             | PRIORITY |
+| ---------------------------- | ------ | ---------------- | -------- |
+| VIOLATION: STYLE_OVERRIDE    | 違反   | 指摘をDに降格    | D        |
+| VIOLATION: INTENT_DISREGARD  | 違反   | ユーザー確認要求 | D        |
+| VIOLATION: SUBJECTIVE_BIAS   | 違反   | 指摘をEに降格    | E        |
+| VIOLATION: SCOPE_EXCESS      | 違反   | 範囲逸脱通知     | D        |
+| STATUS: QUESTION_REQUIRED    | 状態   | レビュー保留     | -        |
+| STATUS: CLARIFICATION_NEEDED | 状態   | 明確化要求       | -        |
 
 **CONSTRAINT**: enum拡張禁止 (closed: true) 。CATEGORY→PRIORITY写像は`:remark`で上書き可。VIOLATION付き指摘は自動降格、STATUS付きは保留状態。
 
@@ -760,22 +766,22 @@ Finding:
 
 ### 5.1 命名規則
 
-| 要素               | 型           | 制約         | スタイル              | 例                   |
-| ------------------ | ------------ | ------------ | --------------------- | -------------------- |
-| ACCEPTANCE/CMD/VAR/EVENT | `<ascii-id>` | 英数字-_     | snake_case/PascalCase | cmd, :buf, ModeChg   |
-| FIELD/RULE         | `<label>`    | 日本語許可   | -                     | 重要度, セクションID |
-| AS                 | -            | 表示名       | 日本語推奨            | ACCEPTANCE cmd AS "コマンド" |
+| 要素                     | 型           | 制約       | スタイル              | 例                           |
+| ------------------------ | ------------ | ---------- | --------------------- | ---------------------------- |
+| ACCEPTANCE/CMD/VAR/EVENT | `<ascii-id>` | 英数字-_   | snake_case/PascalCase | cmd, :buf, ModeChg           |
+| FIELD/RULE               | `<label>`    | 日本語許可 | -                     | 重要度, セクションID         |
+| AS                       | -            | 表示名     | 日本語推奨            | ACCEPTANCE cmd AS "コマンド" |
 
 **NOTE**: コード参照=識別子 | LLM出力=AS優先。
 
 ### 5.2 コーディングスタイル
 
-| 項目     | 規則                                    |
-| -------- | --------------------------------------- |
-| 形式     | インライン (`->`, 120文字) \| ブロック  |
-| EXECUTE  | 1文=1責務、ACCEPTANCE遷移・SET明示      |
-| 制約     | CONSTRAINT/EVENT形式化                  |
-| 出力構造 | トレーサビリティ・再現性保証            |
+| 項目     | 規則                                   |
+| -------- | -------------------------------------- |
+| 形式     | インライン (`->`, 120文字) \| ブロック |
+| EXECUTE  | 1文=1責務、ACCEPTANCE遷移・SET明示     |
+| 制約     | CONSTRAINT/EVENT形式化                 |
+| 出力構造 | トレーサビリティ・再現性保証           |
 
 ### 5.3 EXECUTE 運用ガイドライン
 
@@ -859,7 +865,7 @@ EXECUTE_MODE ::= idle | processing             ; 初期=idle, AS="待機中|処�
 
 ACCEPTANCE は合否や品質評価を意味しない。ACCEPTANCE は文章の受付と処理開始の境界を示す。
 
-```
+```text
 PRINCIPLE ACCEPTANCE semantics (意味固定):
   ACCEPTANCE は合否や品質評価を意味しない
   ACCEPTANCE は文章の受付と処理開始の境界を示す
@@ -889,22 +895,22 @@ RULE user authority:
 
 **ACCEPTANCE遷移規則**:
 
-| 状態    | :buffer状態 | 受付可能コマンド               | ACCEPTANCE遷移   |
-| ------- | ----------- | ------------------------------ | ---------------- |
-| PENDING | 空/構築中   | /begin, /set, /reset, /end, /exit | -                |
-| PENDING | 確定        | /review, /begin, /exit         | /review→ACTIVE   |
-| ACTIVE  | 確定        | /exit (強制終了のみ)           | 完了後→PENDING   |
+| 状態    | :buffer状態 | 受付可能コマンド                  | ACCEPTANCE遷移 |
+| ------- | ----------- | --------------------------------- | -------------- |
+| PENDING | 空/構築中   | /begin, /set, /reset, /end, /exit | -              |
+| PENDING | 確定        | /review, /begin, /exit            | /review→ACTIVE |
+| ACTIVE  | 確定        | /exit (強制終了のみ)              | 完了後→PENDING |
 
 **NOTE**: ACCEPTANCE=PENDING: 文章受付中または待機中、処理しない。ACCEPTANCE=ACTIVE: /review実行中のみ、一時的に処理許可。完了後は自動的にPENDINGに戻る(自動ではなく合意による)。
 
 **EXECUTE_MODE制約**:
 
-| 項目         | 規則                                       |
-| ------------ | ------------------------------------------ |
-| 可視性       | 内部専用、ユーザー不可視                   |
-| 遷移条件     | ACCEPTANCE=ACTIVE時のみ                         |
-| processing時 | ユーザー入力保留、/exit以外無視            |
-| 再入         | /review再入禁止(processing判定)            |
+| 項目         | 規則                                      |
+| ------------ | ----------------------------------------- |
+| 可視性       | 内部専用、ユーザー不可視                  |
+| 遷移条件     | ACCEPTANCE=ACTIVE時のみ                   |
+| processing時 | ユーザー入力保留、/exit以外無視           |
+| 再入         | /review再入禁止(processing判定)           |
 | 出力         | processing時=事実通知のみ(1-2文/10語以内) |
 
 **NOTE**: 事実通知例: "校閲処理中です" (許可) | 説明文例: "〜の理由で確認中" (禁止)。中間結果・判断内容=idle復帰後出力。
@@ -924,32 +930,32 @@ VAR SESSION :dictionary ; 辞書サイトURL(デフォルト設定済み)
 /review [<section>] ::= 校閲実行(全体または特定セクション)
 ```
 
-| フェーズ   | アクション                                                     |
-| ---------- | -------------------------------------------------------------- |
-| 前処理     | EXEC_MODE=processing, CLEAR :review                            |
-| 入力検証   | :buffer検証(定義・非空・100文字以上), 必須変数(:role, :dictionary)確認 |
-| 校閲       | 校閲指示適用                                                   |
-| 後処理     | EXEC_MODE=idle                                                 |
+| フェーズ | アクション                                                             |
+| -------- | ---------------------------------------------------------------------- |
+| 前処理   | EXEC_MODE=processing, CLEAR :review                                    |
+| 入力検証 | :buffer検証(定義・非空・100文字以上), 必須変数(:role, :dictionary)確認 |
+| 校閲     | 校閲指示適用                                                           |
+| 後処理   | EXEC_MODE=idle                                                         |
 
 **CONSTRAINT 入力検証**:
 
-| 項目        | 条件             | 失敗時アクション               |
-| ----------- | ---------------- | ------------------------------ |
-| :buffer定義 | defined(:buffer) | EMIT ProcessFailed, ACCEPTANCE=PENDING   |
-| :buffer非空 | length > 0       | EMIT ProcessFailed, ACCEPTANCE=PENDING   |
-| 文字数      | length >= 100    | 警告("推奨: 100文字以上")      |
+| 項目        | 条件             | 失敗時アクション                       |
+| ----------- | ---------------- | -------------------------------------- |
+| :buffer定義 | defined(:buffer) | EMIT ProcessFailed, ACCEPTANCE=PENDING |
+| :buffer非空 | length > 0       | EMIT ProcessFailed, ACCEPTANCE=PENDING |
+| 文字数      | length >= 100    | 警告("推奨: 100文字以上")              |
 
 **NOTE**: 検証失敗時=診断メッセージ出力。agent/CLI/MCP連携時の挙動安定化。
 
 ### 6.4 優先度定義
 
-| 優先度 | 意味                         | 適用場面                           |
-| ------ | ---------------------------- | ---------------------------------- |
-| S      | 特記事項・変更禁止           | :remark指定、非校閲領域            |
-| A      | 基本方針・共通ルール         | 正確性検証、:role適用              |
-| B      | 正確性・一貫性               | ASCII使用、表記統一                |
-| C      | 品質向上                     | 表記揺れ、文体                     |
-| E      | 個性保持                     | 固有表現、著者スタイル             |
+| 優先度 | 意味                 | 適用場面                |
+| ------ | -------------------- | ----------------------- |
+| S      | 特記事項・変更禁止   | :remark指定、非校閲領域 |
+| A      | 基本方針・共通ルール | 正確性検証、:role適用   |
+| B      | 正確性・一貫性       | ASCII使用、表記統一     |
+| C      | 品質向上             | 表記揺れ、文体          |
+| E      | 個性保持             | 固有表現、著者スタイル  |
 
 **NOTE**: OUTPUT生成時の分類・強調のみに使用。実行順序制御には使用禁止。
 
@@ -959,16 +965,16 @@ VAR SESSION :dictionary ; 辞書サイトURL(デフォルト設定済み)
 OUTPUT ::= Issue ID, 重要度, 指摘種別, 改善点, 修正前, 修正後, 修正理由, 検証根拠
 Issue ID ::= <section>-<nnn>  ; section=小文字英数字, nnn=001-999
 
-| FIELD    | 値                                    |
-| -------- | ------------------------------------- |
-| Issue ID | <section>-<3桁連番>                   |
-| 重要度   | S\|A\|B\|C\|E                         |
-| 指摘種別 | 修正必須\|注意喚起\|判断保留          |
-| 改善点   | 修正理由+提案内容                     |
-| 修正前   | 原文引用                              |
-| 修正後   | 修正案\|"該当なし"\|"提案せず"        |
-| 修正理由 | 修正目的                              |
-| 検証根拠 | :dictionary/:link参照\|"検証不能"     |
+| FIELD    | 値                                |
+| -------- | --------------------------------- |
+| Issue ID | <section>-<3桁連番>               |
+| 重要度   | S\|A\|B\|C\|E                     |
+| 指摘種別 | 修正必須\|注意喚起\|判断保留      |
+| 改善点   | 修正理由+提案内容                 |
+| 修正前   | 原文引用                          |
+| 修正後   | 修正案\|"該当なし"\|"提案せず"    |
+| 修正理由 | 修正目的                          |
+| 検証根拠 | :dictionary/:link参照\|"検証不能" |
 
 **指摘種別**:
 
@@ -984,42 +990,42 @@ Issue ID ::= <section>-<nnn>  ; section=小文字英数字, nnn=001-999
 
 **readability (読みにくさ)**:
 
-| 観点           | 検出条件             |
-| -------------- | -------------------- |
-| 一文の長さ     | 100文字以上          |
-| 主語不明       | 主語省略/曖昧        |
-| 修飾多重化     | 3層以上入れ子        |
-| 接続詞連続     | 3個以上連続          |
-| 代名詞曖昧     | 指示対象不明確       |
+| 観点       | 検出条件       |
+| ---------- | -------------- |
+| 一文の長さ | 100文字以上    |
+| 主語不明   | 主語省略/曖昧  |
+| 修飾多重化 | 3層以上入れ子  |
+| 接続詞連続 | 3個以上連続    |
+| 代名詞曖昧 | 指示対象不明確 |
 
 **inaccuracy (技術的正確性)**:
 
-| 観点             | 検出条件                     |
-| ---------------- | ---------------------------- |
-| 用語誤用         | :dictionary/:link基準違反    |
-| 一般的理解乖離   | 一般的理解と異なる断定表現   |
-| 事実誤認         | :link参照で確認不可な主張    |
-| 曖昧な数量表現   | 主観的表現("多い"など)       |
-| 引用元不明       | 出典不明な統計・事実         |
+| 観点           | 検出条件                   |
+| -------------- | -------------------------- |
+| 用語誤用       | :dictionary/:link基準違反  |
+| 一般的理解乖離 | 一般的理解と異なる断定表現 |
+| 事実誤認       | :link参照で確認不可な主張  |
+| 曖昧な数量表現 | 主観的表現("多い"など)     |
+| 引用元不明     | 出典不明な統計・事実       |
 
 **inconsistency (一貫性)**:
 
-| 観点         | 検出条件                 |
-| ------------ | ------------------------ |
-| 表記揺れ     | 同一概念で異なる表記     |
-| 送り仮名揺れ | 同一語で送り仮名不一致   |
-| 文体不統一   | ですます/である混在      |
-| 記号不統一   | 括弧・引用符・記号混在   |
-| 全角半角混在 | ASCII文字表記揺れ        |
+| 観点         | 検出条件               |
+| ------------ | ---------------------- |
+| 表記揺れ     | 同一概念で異なる表記   |
+| 送り仮名揺れ | 同一語で送り仮名不一致 |
+| 文体不統一   | ですます/である混在    |
+| 記号不統一   | 括弧・引用符・記号混在 |
+| 全角半角混在 | ASCII文字表記揺れ      |
 
 **CATEGORY→PRIORITY写像**:
 
-| Category      | 条件        | PRIORITY |
-| ------------- | ----------- | -------- |
-| inaccuracy    | :linkあり   | A        |
-| inaccuracy    | :linkなし   | B        |
-| inconsistency | -           | B        |
-| readability   | -           | C        |
+| Category      | 条件      | PRIORITY |
+| ------------- | --------- | -------- |
+| inaccuracy    | :linkあり | A        |
+| inaccuracy    | :linkなし | B        |
+| inconsistency | -         | B        |
+| readability   | -         | C        |
 
 **NOTE**: :remarkで上書き可能。複数該当時=最高優先度採用。
 
@@ -1029,27 +1035,29 @@ Issue ID ::= <section>-<nnn>  ; section=小文字英数字, nnn=001-999
 
 #### 校閲指示1: 文章表現・スタイル
 
-| Pri | 観点             | ルール                                                       |
-| --- | ---------------- | ------------------------------------------------------------ |
+| Pri | 観点             | ルール                                                        |
+| --- | ---------------- | ------------------------------------------------------------- |
 | S   | 非校閲領域       | DSL/DEF/RULE/CONSTRAINT/BEGIN INPUT-END INPUT/Appendix=対象外 |
-| S   | :remark指定      | 一切変更禁止                                                 |
-| S   | コードブロック   | 誤字脱字のみ修正可                                           |
-| S   | ASCII            | 英数字・記号=半角                                            |
-| S   | バックティック   | 技術用語/コード/コマンド/ファイル名=`囲み`                   |
-| S   | 技術的正確性     | :dictionary/:link基準                                        |
-| A   | 文法・表現・語彙 | 誤字脱字、不自然表現、送り仮名、助詞連続修正                 |
-| A   | バランス         | 技術文書⇔カジュアルブログ                                    |
-| A   | 冪等性           | 同一条件で一貫した結果                                       |
-| B   | 本文文体         | ですます調                                                   |
-| B   | 箇条書き文体     | である調/体言止め                                            |
-| B   | 手順文体         | 1行目=体言止め, 2行目以降=ですます調可                       |
-| B   | 送り仮名平仮名   | 平仮名                                                       |
-| B   | 「行なう」       | 「行う」→「行なう」                                          |
-| C   | 表記統一         | 表記・文体・句読点の統一                                     |
-| C   | 表記揺れ         | 同一概念の統一表記                                           |
-| E   | 固有表現保持     | "Enjoy!", "Happy Hacking!", "atsushifx です"=変更禁止        |
+| S   | :remark指定      | 一切変更禁止                                                  |
+| S   | コードブロック   | 誤字脱字のみ修正可                                            |
+| S   | ASCII            | 英数字・記号=半角                                             |
+| S   | バックティック   | 技術用語/コード/コマンド/ファイル名=`囲み`                    |
+| S   | 技術的正確性     | :dictionary/:link基準                                         |
+| A   | 文法・表現・語彙 | 誤字脱字、不自然表現、送り仮名、助詞連続修正                  |
+| A   | バランス         | 技術文書⇔カジュアルブログ                                     |
+| A   | 冪等性           | 同一条件で一貫した結果                                        |
+| B   | 本文文体         | ですます調                                                    |
+| B   | 箇条書き文体     | である調/体言止め                                             |
+| B   | 手順文体         | 1行目=体言止め, 2行目以降=ですます調可                        |
+| B   | 送り仮名平仮名   | 平仮名                                                        |
+| B   | 「行なう」       | 「行う」→「行なう」                                           |
+| C   | 表記統一         | 表記・文体・句読点の統一                                      |
+| C   | 表記揺れ         | 同一概念の統一表記                                            |
+| E   | 固有表現保持     | "Enjoy!", "Happy Hacking!", "atsushifx です"=変更禁止         |
 
 **非校閲領域** (自己再帰防止):
+
+```
 
 ```abnf
 非対象 ::= DEF/INSERT/EVENT block
@@ -1075,22 +1083,22 @@ Issue ID ::= <section>-<nnn>  ; section=小文字英数字, nnn=001-999
 
 #### 校閲指示3: 技術的正確性検証
 
-| 条件            | 検証方法                     | 検証失敗時                        |
-| --------------- | ---------------------------- | --------------------------------- |
-| :link指定あり   | :linkから事実・仕様検証      | 「判断保留」+「要出典」           |
-| :link古い(2年+) | 「注意喚起」+「リンク古い」  | -                                 |
-| :link指定なし   | 一般技術常識照合             | 「判断保留」+「検証不能(要出典)」 |
-| 推測・経験談    | 「判断保留」+「個人的見解」  | -                                 |
-| 断定表現        | :linkなし→「推量表現推奨」   | -                                 |
+| 条件            | 検証方法                    | 検証失敗時                        |
+| --------------- | --------------------------- | --------------------------------- |
+| :link指定あり   | :linkから事実・仕様検証     | 「判断保留」+「要出典」           |
+| :link古い(2年+) | 「注意喚起」+「リンク古い」 | -                                 |
+| :link指定なし   | 一般技術常識照合            | 「判断保留」+「検証不能(要出典)」 |
+| 推測・経験談    | 「判断保留」+「個人的見解」 | -                                 |
+| 断定表現        | :linkなし→「推量表現推奨」  | -                                 |
 
 **NOTE**: 検証プロトコル=モデル間判定一貫性保証。「全指摘」or「無指摘」両極端防止。
 
 ### 6.8 プロンプト共通変数
 
-| 変数        | スコープ | 用途                     | デフォルト         |
-| ----------- | -------- | ------------------------ | ------------------ |
-| :role       | SESSION  | AIペルソナ定義           | 下記リスト         |
-| :dictionary | SESSION  | 辞書サイト(表記揺れ基準) | 下記URLリスト      |
+| 変数        | スコープ | 用途                     | デフォルト    |
+| ----------- | -------- | ------------------------ | ------------- |
+| :role       | SESSION  | AIペルソナ定義           | 下記リスト    |
+| :dictionary | SESSION  | 辞書サイト(表記揺れ基準) | 下記URLリスト |
 
 **NOTE**: :role=校閲品質基準・観点決定。:dictionary=日本語表記・送り仮名・専門用語基準。
 
@@ -1111,14 +1119,14 @@ output-phase   ::= ACCEPTANCE=PENDING (再実行可能)
 
 ### A.2 校閲処理手順
 
-| 順序 | フェーズ       | 動作                                           |
-| ---- | -------------- | ---------------------------------------------- |
-| 1    | 入力検証       | EMIT ProcessStarted -> :buffer検証、必須変数確認 |
-| 2    | 校閲実行       | 優先度(S/A/B/C/E)別チェック、改善点抽出        |
-| 3    | 結果整理       | 行番号順ソート                                 |
-| 4    | 保存・出力     | :review保存、出力形式整形                      |
-| 5    | 完了           | EMIT ProcessCompleted -> ACCEPTANCE=PENDING          |
-| 6    | エラー処理     | EMIT ProcessFailed -> ACCEPTANCE=PENDING             |
+| 順序 | フェーズ   | 動作                                             |
+| ---- | ---------- | ------------------------------------------------ |
+| 1    | 入力検証   | EMIT ProcessStarted -> :buffer検証、必須変数確認 |
+| 2    | 校閲実行   | 優先度(S/A/B/C/E)別チェック、改善点抽出          |
+| 3    | 結果整理   | 行番号順ソート                                   |
+| 4    | 保存・出力 | :review保存、出力形式整形                        |
+| 5    | 完了       | EMIT ProcessCompleted -> ACCEPTANCE=PENDING      |
+| 6    | エラー処理 | EMIT ProcessFailed -> ACCEPTANCE=PENDING         |
 
 **NOTE**: 利用可能コマンド=`/review [セクション]`, `/begin`。
 
@@ -1128,12 +1136,12 @@ output-phase   ::= ACCEPTANCE=PENDING (再実行可能)
 
 ### B.1 変数定義
 
-| 変数        | スコープ | 用途                       | 形式    | デフォルト     |
-| ----------- | -------- | -------------------------- | ------- | -------------- |
-| :role       | SESSION  | AIペルソナ(校閲品質基準)   | list    | 下記リスト     |
-| :dictionary | SESSION  | 辞書サイト(表記揺れ基準)   | list    | 下記URLリスト  |
-| :link       | SESSION  | 参考資料(事実確認・仕様検証) | list    | ""             |
-| :remark     | SESSION  | 追加指示(優先度S相当)      | heredoc | ""             |
+| 変数        | スコープ | 用途                         | 形式    | デフォルト    |
+| ----------- | -------- | ---------------------------- | ------- | ------------- |
+| :role       | SESSION  | AIペルソナ(校閲品質基準)     | list    | 下記リスト    |
+| :dictionary | SESSION  | 辞書サイト(表記揺れ基準)     | list    | 下記URLリスト |
+| :link       | SESSION  | 参考資料(事実確認・仕様検証) | list    | ""            |
+| :remark     | SESSION  | 追加指示(優先度S相当)        | heredoc | ""            |
 
 **NOTE**: :dictionary=日本語表記・送り仮名・専門用語基準。:link=公式ドキュメント・信頼できる技術情報源優先。:remark=他ルールより優先。
 

--- a/tech-articles-prompt/article-review.prompt
+++ b/tech-articles-prompt/article-review.prompt
@@ -11,6 +11,8 @@ meta:
     - Copyright (c) 2025 atsushifx <https://github.com/atsushifx/>
 ---
 
+<!-- markdownlint-disable line-length -->
+
 ## Overview (概要)
 
 ## 0. メタ記法
@@ -62,7 +64,7 @@ block-type = DSL / MACRO / RULE / INPUT / OUTPUT
 
 本 DSL の基本パターンを示します。
 
-```
+```text
 BEGIN INPUT
   SET :buffer = """
 技術記事の内容をここに記述します。
@@ -193,8 +195,8 @@ field       = 1*(ALPHA / DIGIT / "_")
 構文解析 → 意味論評価 → 実行
 ```
 
-| レイヤー | 役割                       |
-| -------- | -------------------------- |
+| レイヤー | 役割                        |
+| -------- | --------------------------- |
 | 構文     | 文法的正当性 (パース可能性) |
 | 意味論   | 実行時意味 (制約・状態遷移) |
 
@@ -243,31 +245,32 @@ EXECUTE_MODE ::= idle | processing             ; 初期=idle
 
 **層分離原則**:
 
-| レイヤー | 変数       | スコープ             | 遷移条件               | 責務           |
-| -------- | ---------- | -------------------- | ---------------------- | -------------- |
-| UI 層    | SESSION_PHASE | command/input/review | /begin, /end, /exit    | ユーザー対話   |
-| 処理層   | EXECUTE_MODE | idle/processing      | SESSION_PHASE=review時 | 処理実行制御   |
+| レイヤー | 変数          | スコープ             | 遷移条件               | 責務         |
+| -------- | ------------- | -------------------- | ---------------------- | ------------ |
+| UI 層    | SESSION_PHASE | command/input/review | /begin, /end, /exit    | ユーザー対話 |
+| 処理層   | EXECUTE_MODE  | idle/processing      | SESSION_PHASE=review時 | 処理実行制御 |
 
-**NOTE**: SESSION_PHASE (UI 層) | EXECUTE_MODE (処理層) は独立。EXECUTE_MODE は SESSION_PHASE=review 時のみ遷移可能。レビュー系では generation-status 不要。
+**NOTE**:
+SESSION_PHASE (UI 層) | EXECUTE_MODE (処理層) は独立。EXECUTE_MODE は SESSION_PHASE=review 時のみ遷移可能。レビュー系では generation-status 不要。
 
 **遷移規則**:
 
-| モード       | 許可遷移                 | 禁止遷移                          | 条件            |
-| ------------ | ------------------------ | --------------------------------- | --------------- |
-| ACCEPTANCE   | PENDING→ACTIVE(一時)→PENDING | 自動遷移禁止                      | /review のみ    |
-| EXECUTE_MODE | idle→proc→idle           | proc→proc                         | ACCEPTANCE=ACTIVE時のみ |
-| 出力制約     | processing時=事実通知のみ | processing時=説明文・考察・推論禁止 | -               |
+| モード       | 許可遷移                     | 禁止遷移                            | 条件                    |
+| ------------ | ---------------------------- | ----------------------------------- | ----------------------- |
+| ACCEPTANCE   | PENDING→ACTIVE(一時)→PENDING | 自動遷移禁止                        | /review のみ            |
+| EXECUTE_MODE | idle→proc→idle               | proc→proc                           | ACCEPTANCE=ACTIVE時のみ |
+| 出力制約     | processing時=事実通知のみ    | processing時=説明文・考察・推論禁止 | -                       |
 
 ### 2.4 コマンド制約
 
-| コマンド | 実行ACCEPTANCE     | 副作用                                      | 再入 |
-| -------- | ------------------ | ------------------------------------------- | ---- |
-| /begin   | PENDING            | CLEAR :buffer                               | 可   |
-| /review  | PENDING→ACTIVE(一時) | EXEC_MODE: idle→proc→idle                   | 禁止 |
-| /write   | PENDING→ACTIVE(一時) | EXEC_MODE: idle→proc→idle                   | 禁止 |
-| /exit    | *                  | CLEAR ALL, EXEC_MODE=idle                   | -    |
-| /reset   | *                  | CLEAR :var.. (スコープ内のみ)                | -    |
-| /set     | *                  | SET :var=value (スコープ内上書き許可)        | -    |
+| コマンド | 実行ACCEPTANCE       | 副作用                                | 再入 |
+| -------- | -------------------- | ------------------------------------- | ---- |
+| /begin   | PENDING              | CLEAR :buffer                         | 可   |
+| /review  | PENDING→ACTIVE(一時) | EXEC_MODE: idle→proc→idle             | 禁止 |
+| /write   | PENDING→ACTIVE(一時) | EXEC_MODE: idle→proc→idle             | 禁止 |
+| /exit    | *                    | CLEAR ALL, EXEC_MODE=idle             | -    |
+| /reset   | *                    | CLEAR :var.. (スコープ内のみ)         | -    |
+| /set     | *                    | SET :var=value (スコープ内上書き許可) | -    |
 
 **NOTE**: /review, /write = EXEC_MODE遷移必須、再入禁止。ACCEPTANCE=* はすべての状態で実行可能。
 
@@ -282,14 +285,14 @@ EXECUTE_MODE ::= idle | processing             ; 初期=idle
 
 ### 2.6 実行規約
 
-| 項目      | 規則                                      |
-| --------- | ----------------------------------------- |
-| 評価順序  | DEF順・上から下                           |
-| 再定義    | 禁止                                      |
-| VAR       | 暗黙可変、初期値=空文字列                 |
-| EXECUTE   | 列挙手順のみ (Appendix参照のみ、実行禁止) |
-| 停止条件  | LLM判断依存、明示推奨                     |
-| アクション | CLEAR -> SET -> EXECUTE -> ACCEPTANCE       |
+| 項目       | 規則                                      |
+| ---------- | ----------------------------------------- |
+| 評価順序   | DEF順・上から下                           |
+| 再定義     | 禁止                                      |
+| VAR        | 暗黙可変、初期値=空文字列                 |
+| EXECUTE    | 列挙手順のみ (Appendix参照のみ、実行禁止) |
+| 停止条件   | LLM判断依存、明示推奨                     |
+| アクション | CLEAR -> SET -> EXECUTE -> ACCEPTANCE     |
 
 **NOTE**: CLEAR ALL = 全スコープクリア。`DEF /begin THEN CLEAR :buffer END` (ACCEPTANCE状態不変)
 
@@ -315,12 +318,12 @@ EXECUTE_MODE ::= idle | processing             ; 初期=idle
 
 ### 2.9 CONSTRAINT
 
-| 要素        | 用途               | 禁止用途                     |
-| ----------- | ------------------ | ---------------------------- |
-| PRIORITY    | 衝突時選択指針     | 適用可否・評価順序制御       |
-| description | 説明文             | 判定・制御ロジック           |
-| label       | 表示名             | 識別子・検索キー             |
-| free-text   | 自由記述           | パース・構文解析             |
+| 要素        | 用途           | 禁止用途               |
+| ----------- | -------------- | ---------------------- |
+| PRIORITY    | 衝突時選択指針 | 適用可否・評価順序制御 |
+| description | 説明文         | 判定・制御ロジック     |
+| label       | 表示名         | 識別子・検索キー       |
+| free-text   | 自由記述       | パース・構文解析       |
 
 **NOTE**: PRIORITY = OUTPUT生成時の優先度表示・複数指摘競合時の重み付けのみ。
 
@@ -328,12 +331,12 @@ EXECUTE_MODE ::= idle | processing             ; 初期=idle
 
 #### 基本処理規則
 
-| 状況     | 処理                                       | ACCEPTANCE/EXEC     |
-| -------- | ------------------------------------------ | ------------------- |
-| 情報不足 | EMIT ProcessFailed -> Open Questions出力   | 現状維持            |
-| 判断不能 | CONSTRAINT確認 -> :remark優先 -> 保守選択  | 現状維持            |
-| 未完成   | 停止 -> /begin再入力促進                   | ACCEPTANCE=PENDING  |
-| 実行中断 | EXEC_MODE: proc->idle, ACCEPTANCE復帰      | SESSION保持         |
+| 状況     | 処理                                      | ACCEPTANCE/EXEC    |
+| -------- | ----------------------------------------- | ------------------ |
+| 情報不足 | EMIT ProcessFailed -> Open Questions出力  | 現状維持           |
+| 判断不能 | CONSTRAINT確認 -> :remark優先 -> 保守選択 | 現状維持           |
+| 未完成   | 停止 -> /begin再入力促進                  | ACCEPTANCE=PENDING |
+| 実行中断 | EXEC_MODE: proc->idle, ACCEPTANCE復帰     | SESSION保持        |
 
 NOTE: 未完成=TODO/メモ/箇条のみ検出時。エラー時=SESSION/REVIEW 変数保持。
 
@@ -390,19 +393,19 @@ NOTE: 未完成=TODO/メモ/箇条のみ検出時。エラー時=SESSION/REVIEW 
 
 ### 2.11 フォールバック規則
 
-| カテゴリ | 状況 | フォールバック動作 | ACCEPTANCE/EXEC |
-|---------|------|-------------------|-----------------|
-| **コマンド** | 不明/構文エラー | 基本モード縮退 → エラー通知 | ACCEPTANCE=PENDING |
-| | パラメータ欠落 | デフォルト値使用 (全セクション対象)  | 現状維持 |
-| **変数** | 未定義 | `[UNRESOLVED:変数名]` 付与 | - |
-| | 型不一致 | 文字列として扱う | - |
-| | スコープ違反 | SESSION スコープで再検索 | - |
-| **状態遷移** | ACCEPTANCE自動遷移 | PENDING に強制復帰 | SESSION保持 |
-| | EXEC_MODE再入 | 実行拒否 → エラー通知 | 現状維持 |
-| | 禁止遷移試行 | 遷移キャンセル → 警告 | 現状維持 |
-| **OUTPUT** | generation-status=INCOMPLETE | 生成スキップ → 情報不足通知 | Open Questions出力 |
-| | CATEGORY判定不能 | `[CATEGORY:unknown]` + PRIORITY=B | デフォルト分類 |
-| | PRIORITY算出失敗 | PRIORITY=B (保守的設定)  | - |
+| カテゴリ     | 状況                         | フォールバック動作                  | ACCEPTANCE/EXEC    |
+| ------------ | ---------------------------- | ----------------------------------- | ------------------ |
+| **コマンド** | 不明/構文エラー              | 基本モード縮退 → エラー通知         | ACCEPTANCE=PENDING |
+|              | パラメータ欠落               | デフォルト値使用 (全セクション対象) | 現状維持           |
+| **変数**     | 未定義                       | `[UNRESOLVED:変数名]` 付与          | -                  |
+|              | 型不一致                     | 文字列として扱う                    | -                  |
+|              | スコープ違反                 | SESSION スコープで再検索            | -                  |
+| **状態遷移** | ACCEPTANCE自動遷移           | PENDING に強制復帰                  | SESSION保持        |
+|              | EXEC_MODE再入                | 実行拒否 → エラー通知               | 現状維持           |
+|              | 禁止遷移試行                 | 遷移キャンセル → 警告               | 現状維持           |
+| **OUTPUT**   | generation-status=INCOMPLETE | 生成スキップ → 情報不足通知         | Open Questions出力 |
+|              | CATEGORY判定不能             | `[CATEGORY:unknown]` + PRIORITY=B   | デフォルト分類     |
+|              | PRIORITY算出失敗             | PRIORITY=B (保守的設定)             | -                  |
 
 **処理順序**: 1. CONSTRAINT確認 → 2. `:remark`優先適用 → 3. フォールバック規則 → 4. 保守的設定
 
@@ -425,11 +428,11 @@ PHILOSOPHY REVIEW:
 
 **介入レベル判定**:
 
-| レベル | 判定条件 | 根拠要件 | PRIORITY |
-|--------|---------|---------|----------|
-| HIGH | 技術的誤り検出 | :link検証済 OR 公式Doc | A |
-| MEDIUM | 論理的不整合検出 | 文書内複数箇所比較 | B |
-| LOW | 表現改善提案 | ベストプラクティス | C |
+| レベル | 判定条件         | 根拠要件               | PRIORITY |
+| ------ | ---------------- | ---------------------- | -------- |
+| HIGH   | 技術的誤り検出   | :link検証済 OR 公式Doc | A        |
+| MEDIUM | 論理的不整合検出 | 文書内複数箇所比較     | B        |
+| LOW    | 表現改善提案     | ベストプラクティス     | C        |
 
 ### 3.2 Fail-Fast Policy
 
@@ -444,9 +447,10 @@ RULE FAIL_FAST:
 
 **判定基準 (形式化・検出方法)**:
 
-| 条件                | 検出方法                                          | 閾値                   | 根拠             |
-| ------------------- | ------------------------------------------------- | ---------------------- | ---------------- |
-| structural_collapse | 見出し階層飛び: `^#{1,6}` regex, 必須section欠落  | gap>1 OR 概要/結論なし | 構造破綻         |
+| 条件                | 検出方法                                         | 閾値                   | 根拠     |
+| ------------------- | ------------------------------------------------ | ---------------------- | -------- |
+| structural_collapse | 見出し階層飛び: `^#{1,6}` regex, 必須section欠落 | gap>1 OR 概要/結論なし | 構造破綻 |
+
 | technical_fatality  | コードブロック未閉: `` ``` `` ペア不整合, API誤用 | unclosed>0 OR errors≥3 | 実行不可能       |
 | unreadability       | 主題文欠落率, 接続詞密度                          | 欠落率>50% OR 接続<10% | 意図伝達不可     |
 | insufficient_length | Unicode文字数 (コードブロック除外)                | <500文字               | レビュー対象不足 |
@@ -528,12 +532,12 @@ RULE PROPOSAL_GENERATION:
       - VIOLATION not in {STYLE_OVERRIDE, INTENT_DISREGARD}
 
     GENERATION_RULES:
-      | CATEGORY      | Generate? | Allowed Types                    |
-      |---------------|-----------|----------------------------------|
-      | inaccuracy    | ❌         | (skip - 事実確認必要)             |
-      | inconsistency | ✅         | clarification, restructure       |
-      | readability   | ✅         | rephrase                         |
-      | unknown       | ❌         | (skip - 判定不能)                 |
+      | CATEGORY      | Generate? | Allowed Types              |
+      | ------------- | --------- | -------------------------- |
+      | inaccuracy    | ❌         | (skip - 事実確認必要)      |
+      | inconsistency | ✅         | clarification, restructure |
+      | readability   | ✅         | rephrase                   |
+      | unknown       | ❌         | (skip - 判定不能)          |
 
     EXCLUSION:
       - Finding with VIOLATION → skip
@@ -575,25 +579,25 @@ END INPUT
 
 ### 4.2 標準コマンド
 
-| コマンド            | 動作                    | 値形式            |
-| ------------------- | ----------------------- | ----------------- |
-| /begin              | CLEAR :buffer           | -                 |
-| /end                | :buffer確定             | -                 |
-| /exit               | CLEAR ALL               | -                 |
-| /reset <:var..>     | CLEAR :var..            | -                 |
-| /set <:var>=<value> | SET :var=value          | "text"\|\|\|"""" |
+| コマンド            | 動作           | 値形式           |
+| ------------------- | -------------- | ---------------- |
+| /begin              | CLEAR :buffer  | -                |
+| /end                | :buffer確定    | -                |
+| /exit               | CLEAR ALL      | -                |
+| /reset <:var..>     | CLEAR :var..   | -                |
+| /set `:var`=`value` | SET :var=value | "text"\|\|\|"""" |
 
 **NOTE**: スコープ内上書き可。SESSION=/exit, REVIEW=/begin。
 
 ### 4.3 標準変数
 
-| 変数    | スコープ | 用途                             | クリア |
-| ------- | -------- | -------------------------------- | ------ |
-| :role   | SESSION  | ユーザー役割                     | /exit  |
-| :link   | SESSION  | 参考URL (文体抽象化、模倣禁止)   | /exit  |
-| :remark | SESSION  | 特記事項                         | /exit  |
-| :buffer | REVIEW   | 入力蓄積                         | /begin |
-| :review | REVIEW   | 処理結果                         | /begin |
+| 変数    | スコープ | 用途                           | クリア |
+| ------- | -------- | ------------------------------ | ------ |
+| :role   | SESSION  | ユーザー役割                   | /exit  |
+| :link   | SESSION  | 参考URL (文体抽象化、模倣禁止) | /exit  |
+| :remark | SESSION  | 特記事項                       | /exit  |
+| :buffer | REVIEW   | 入力蓄積                       | /begin |
+| :review | REVIEW   | 処理結果                       | /begin |
 
 ### 4.4 標準イベント
 
@@ -744,7 +748,8 @@ Finding:
   finding_separator: "\n---\n" # 指摘間区切り
 ```
 
-**CONSTRAINT**: フィールド順序厳守(1→9)。識別子=セッション内一意。VIOLATION付き=自動降格。enum拡張禁止(closed: true)。該当箇所=4.5で定義されたLOCATION形式。meta_state は discriminator として OUTPUT variant を決定。
+CONSTRAINT: フィールド順序厳守(1→9)。識別子=セッション内一意。VIOLATION付き=自動降格。enum拡張禁止(closed: true)。
+該当箇所=4.5で定義されたLOCATION形式。meta_state は discriminator として OUTPUT variant を決定。
 
 #### Proposal形式 (proposals 配列要素)
 
@@ -829,31 +834,31 @@ ReviewResult:
 
 #### CATEGORY/PRIORITY定義
 
-| CATEGORY | 意味 | デフォルトPRIORITY | 使用条件 |
-|----------|------|-------------------|---------|
-| inaccuracy | 技術的誤り | A (:link有) / B (:linkなし) | 事実誤認、API誤用、コードバグ |
-| inconsistency | 不整合 | B | 用語不統一、論理矛盾 |
-| readability | 可読性 | C | 冗長表現、構造改善 |
-| unknown | 判定不能 | B (保守的設定)  | フォールバック専用 |
+| CATEGORY      | 意味       | デフォルトPRIORITY          | 使用条件                      |
+| ------------- | ---------- | --------------------------- | ----------------------------- |
+| inaccuracy    | 技術的誤り | A (:link有) / B (:linkなし) | 事実誤認、API誤用、コードバグ |
+| inconsistency | 不整合     | B                           | 用語不統一、論理矛盾          |
+| readability   | 可読性     | C                           | 冗長表現、構造改善            |
+| unknown       | 判定不能   | B (保守的設定)              | フォールバック専用            |
 
-| PRIORITY | 意味 | 用途 |
-|----------|------|------|
-| A | 最高優先度 (致命的)  | 技術的誤り (:link検証済み)  |
-| B | 高優先度 (重要)  | 構造的問題、不整合、技術的誤り (未検証)  |
-| C | 中優先度 (推奨)  | 可読性、表現改善 |
-| D | 低優先度 (任意)  | スタイル提案、哲学違反降格 |
-| E | 最低優先度 (情報)  | 参考情報、補足 |
+| PRIORITY | 意味                | 用途                                    |
+| -------- | ------------------- | --------------------------------------- |
+| A        | 最高優先度 (致命的) | 技術的誤り (:link検証済み)              |
+| B        | 高優先度 (重要)     | 構造的問題、不整合、技術的誤り (未検証) |
+| C        | 中優先度 (推奨)     | 可読性、表現改善                        |
+| D        | 低優先度 (任意)     | スタイル提案、哲学違反降格              |
+| E        | 最低優先度 (情報)   | 参考情報、補足                          |
 
 #### VIOLATION/STATUS定義
 
-| ラベル | タイプ | 効果 | PRIORITY |
-|--------|--------|------|----------|
-| VIOLATION: STYLE_OVERRIDE | 違反 | 指摘をDに降格 | D |
-| VIOLATION: INTENT_DISREGARD | 違反 | ユーザー確認要求 | D |
-| VIOLATION: SUBJECTIVE_BIAS | 違反 | 指摘をEに降格 | E |
-| VIOLATION: SCOPE_EXCESS | 違反 | 範囲逸脱通知 | D |
-| STATUS: QUESTION_REQUIRED | 状態 | レビュー保留 | - |
-| STATUS: CLARIFICATION_NEEDED | 状態 | 明確化要求 | - |
+| ラベル                       | タイプ | 効果             | PRIORITY |
+| ---------------------------- | ------ | ---------------- | -------- |
+| VIOLATION: STYLE_OVERRIDE    | 違反   | 指摘をDに降格    | D        |
+| VIOLATION: INTENT_DISREGARD  | 違反   | ユーザー確認要求 | D        |
+| VIOLATION: SUBJECTIVE_BIAS   | 違反   | 指摘をEに降格    | E        |
+| VIOLATION: SCOPE_EXCESS      | 違反   | 範囲逸脱通知     | D        |
+| STATUS: QUESTION_REQUIRED    | 状態   | レビュー保留     | -        |
+| STATUS: CLARIFICATION_NEEDED | 状態   | 明確化要求       | -        |
 
 **CONSTRAINT**: enum拡張禁止 (closed: true) 。CATEGORY→PRIORITY写像は`:remark`で上書き可。VIOLATION付き指摘は自動降格、STATUS付きは保留状態。
 
@@ -863,34 +868,34 @@ ReviewResult:
 
 ### 5.1 命名規則
 
-| 要素               | 型           | 制約         | スタイル              | 例                   |
-| ------------------ | ------------ | ------------ | --------------------- | -------------------- |
-| ACCEPTANCE/CMD/VAR/EVENT | `<ascii-id>` | 英数字-_     | snake_case/PascalCase | PENDING, :buf, ProcessStarted   |
-| FIELD/RULE         | `<label>`    | 日本語許可   | -                     | 重要度, セクションID |
-| AS                 | -            | 表示名       | 日本語推奨            | ACCEPTANCE PENDING AS "受付中" |
+| 要素                     | 型           | 制約       | スタイル              | 例                             |
+| ------------------------ | ------------ | ---------- | --------------------- | ------------------------------ |
+| ACCEPTANCE/CMD/VAR/EVENT | `<ascii-id>` | 英数字-_   | snake_case/PascalCase | PENDING, :buf, ProcessStarted  |
+| FIELD/RULE               | `<label>`    | 日本語許可 | -                     | 重要度, セクションID           |
+| AS                       | -            | 表示名     | 日本語推奨            | ACCEPTANCE PENDING AS "受付中" |
 
 **NOTE**: コード参照=識別子 | LLM出力=AS優先。
 
 ### 5.2 コーディングスタイル
 
-| 項目     | 規則                                    |
-| -------- | --------------------------------------- |
-| 形式     | インライン (`->`, 120文字) \| ブロック  |
-| EXECUTE  | 1文=1責務、ACCEPTANCE遷移・SET明示      |
-| 制約     | CONSTRAINT/EVENT形式化                  |
-| 出力構造 | トレーサビリティ・再現性保証            |
+| 項目     | 規則                                   |
+| -------- | -------------------------------------- |
+| 形式     | インライン (`->`, 120文字) \| ブロック |
+| EXECUTE  | 1文=1責務、ACCEPTANCE遷移・SET明示     |
+| 制約     | CONSTRAINT/EVENT形式化                 |
+| 出力構造 | トレーサビリティ・再現性保証           |
 
 ### 5.3 EXECUTE 運用ガイドライン
 
 EXECUTE 文は操作的ディレクティブ (operational directive) であり、慎重な使用が必要です。
 
-| リスク            | アンチパターン                 | 推奨パターン                 | ガイドライン                                 |
-| ----------------- | ------------------------------ | ---------------------------- | -------------------------------------------- |
-| verbosity         | 長大な EXECUTE 文              | 段階的 EXECUTE 分割          | 1 statement = 1 責務原則                     |
-| state_deviation   | EXECUTE 内で暗黙的状態遷移     | 明示的 SET 文で状態変更      | SESSION_PHASE 遷移は明示的に SET で記述      |
-| implicit_trans    | 事後条件を暗黙的に仮定         | CONSTRAINT で明記            | 停止条件・前提条件は形式化                   |
-| flow_control_leak | EXECUTE で通常フロー制御を迂回 | COMMAND による明示的制御     | EXECUTE は例外処理のみ、通常フローは COMMAND |
-| execution_assumed | Appendix 記載=実行と誤解       | 「参照のみ・実行禁止」を明記 | EXECUTE は列挙手順のみ (実行は LLM 判断)     |
+| リスク            | アンチパターン                 | 推奨パターン                 | ガイドライン                             |
+| ----------------- | ------------------------------ | ---------------------------- | ---------------------------------------- |
+| verbosity         | 長大な EXECUTE 文              | 段階的 EXECUTE 分割          | 1 statement = 1 責務原則                 |
+| state_deviation   | EXECUTE 内で暗黙的状態遷移     | 明示的 SET 文で状態変更      | SESSION_PHASE 遷移は明示的に SET で記述  |
+| implicit_trans    | 事後条件を暗黙的に仮定         | CONSTRAINT で明記            | 停止条件・前提条件は形式化               |
+| flow_control_leak | EXECUTE で通常フロー制御を迂回 | COMMAND による明示的制御     | 通常フローは COMMAND で制御              |
+| execution_assumed | Appendix 記載=実行と誤解       | 「参照のみ・実行禁止」を明記 | EXECUTE は列挙手順のみ (実行は LLM 判断) |
 
 **CONSTRAINT**:
 
@@ -992,23 +997,23 @@ RULE user authority:
 
 **ACCEPTANCE遷移規則**:
 
-| 状態    | :buffer状態 | 受付可能コマンド               | ACCEPTANCE遷移   |
-| ------- | ----------- | ------------------------------ | ---------------- |
-| PENDING | 空/構築中   | /begin, /set, /reset, /end, /exit | -                |
-| PENDING | 確定        | /review, /begin, /exit         | /review→ACTIVE   |
-| ACTIVE  | 確定        | /exit (強制終了のみ)           | 完了後→PENDING   |
+| 状態    | :buffer状態 | 受付可能コマンド                  | ACCEPTANCE遷移 |
+| ------- | ----------- | --------------------------------- | -------------- |
+| PENDING | 空/構築中   | /begin, /set, /reset, /end, /exit | -              |
+| PENDING | 確定        | /review, /begin, /exit            | /review→ACTIVE |
+| ACTIVE  | 確定        | /exit (強制終了のみ)              | 完了後→PENDING |
 
 **NOTE**: ACCEPTANCE=PENDING: 文章受付中または待機中、処理しない。ACCEPTANCE=ACTIVE: /review実行中のみ、一時的に処理許可。完了後は自動的にPENDINGに戻る(自動ではなく合意による)。
 
 **EXECUTE_MODE制約**:
 
-| 項目        | 規則                                   |
-| ----------- | -------------------------------------- |
-| 可視性      | 内部専用、ユーザー不可視               |
-| 遷移条件    | ACCEPTANCE=ACTIVE時のみ                     |
-| processing時 | ユーザー入力保留、/exit以外無視        |
-| 再入        | /review再入禁止(processing判定)        |
-| 出力        | processing時=事実通知のみ(1-2文/10語以内) |
+| 項目         | 規則                                      |
+| ------------ | ----------------------------------------- |
+| 可視性       | 内部専用、ユーザー不可視                  |
+| 遷移条件     | ACCEPTANCE=ACTIVE時のみ                   |
+| processing時 | ユーザー入力保留、/exit以外無視           |
+| 再入         | /review再入禁止(processing判定)           |
+| 出力         | processing時=事実通知のみ(1-2文/10語以内) |
 
 **NOTE**: 事実通知例: "レビュー処理中です" (許可) | 説明文例: "〜の理由で確認中" (禁止)。中間結果・判断内容=idle復帰後出力。
 
@@ -1042,20 +1047,20 @@ VAR REVIEW :appendix      ; 技術用語集(Markdown箇条書き形式)
 
 #### /review定義
 
-| フェーズ    | アクション                           |
-| ----------- | ------------------------------------ |
-| 前処理      | EXEC_MODE=processing, CLEAR :review  |
-| 入力検証    | :buffer検証(定義・非空・100文字以上) |
-| レビュー    | レビュー指示1-3適用                  |
-| 後処理      | EXEC_MODE=idle                       |
+| フェーズ | アクション                           |
+| -------- | ------------------------------------ |
+| 前処理   | EXEC_MODE=processing, CLEAR :review  |
+| 入力検証 | :buffer検証(定義・非空・100文字以上) |
+| レビュー | レビュー指示1-3適用                  |
+| 後処理   | EXEC_MODE=idle                       |
 
 **CONSTRAINT 入力検証**:
 
-| 項目         | 条件             | 失敗時アクション                   |
-| ------------ | ---------------- | ---------------------------------- |
-| :buffer定義  | defined(:buffer) | EMIT ProcessFailed, ACCEPTANCE=PENDING       |
-| :buffer非空  | length > 0       | EMIT ProcessFailed, ACCEPTANCE=PENDING       |
-| 文字数       | length >= 100    | 警告("推奨: 100文字以上")          |
+| 項目        | 条件             | 失敗時アクション                       |
+| ----------- | ---------------- | -------------------------------------- |
+| :buffer定義 | defined(:buffer) | EMIT ProcessFailed, ACCEPTANCE=PENDING |
+| :buffer非空 | length > 0       | EMIT ProcessFailed, ACCEPTANCE=PENDING |
+| 文字数      | length >= 100    | 警告("推奨: 100文字以上")              |
 
 **NOTE**: 検証失敗時=診断メッセージ出力。agent/CLI/MCP連携時の挙動安定化。
 
@@ -1063,28 +1068,28 @@ VAR REVIEW :appendix      ; 技術用語集(Markdown箇条書き形式)
 
 **8軸評価** (0.0-10.0):
 
-| 軸                 | 評価観点                       |
-| ------------------ | ------------------------------ |
-| 関心度             | 読者の興味喚起                 |
-| オリジナリティ     | 構成・視点・内容の独自性       |
-| テクニカル         | 技術的正確性・信頼性           |
-| ロジック           | 論理的展開・段階的理解可能性   |
-| リーダビリティ     | 表現・文法・語彙の整合性       |
-| ユースフル         | 実装可能性・再現性             |
-| エンゲージメント   | 共感・好奇心喚起               |
-| ビジュアル補助     | 表・図・コードブロックの効果性 |
+| 軸               | 評価観点                       |
+| ---------------- | ------------------------------ |
+| 関心度           | 読者の興味喚起                 |
+| オリジナリティ   | 構成・視点・内容の独自性       |
+| テクニカル       | 技術的正確性・信頼性           |
+| ロジック         | 論理的展開・段階的理解可能性   |
+| リーダビリティ   | 表現・文法・語彙の整合性       |
+| ユースフル       | 実装可能性・再現性             |
+| エンゲージメント | 共感・好奇心喚起               |
+| ビジュアル補助   | 表・図・コードブロックの効果性 |
 
 **NOTE**: レーダーチャート+各軸スコア・短評+総括を出力。
 
 ### 6.4 優先度定義
 
-| 優先度 | 意味                     | 適用場面                   |
-| ------ | ------------------------ | -------------------------- |
+| 優先度 | 意味                     | 適用場面                    |
+| ------ | ------------------------ | --------------------------- |
 | S      | 特記事項・変更禁止       | :remark指定、非レビュー領域 |
-| A      | 基本方針・共通ルール     | 文法・表現・技術的正確性   |
-| B      | 文法・正確性影響         | 文体・送り仮名・変数反映   |
-| C      | 品質向上提案             | 可読性向上・スタイル改善   |
-| E      | 文体アイデンティティ保持 | 固有表現・口語トーン       |
+| A      | 基本方針・共通ルール     | 文法・表現・技術的正確性    |
+| B      | 文法・正確性影響         | 文体・送り仮名・変数反映    |
+| C      | 品質向上提案             | 可読性向上・スタイル改善    |
+| E      | 文体アイデンティティ保持 | 固有表現・口語トーン        |
 
 **NOTE**: OUTPUT生成時の分類・強調のみに使用。実行順序制御には使用禁止。
 
@@ -1095,15 +1100,15 @@ OUTPUT ::= Issue ID, 重要度, 指摘種別, 改善点, 修正前, 修正後, �
 Issue ID ::= <section>-<nnn>  ; section=小文字英数字, nnn=001-999
 ```
 
-| FIELD    | 値                                |
-| -------- | --------------------------------- |
-| Issue ID | <section>-<3桁連番>               |
-| 重要度   | S\|A\|B\|C\|E                     |
-| 指摘種別 | 修正必須\|注意喚起\|判断保留      |
-| 改善点   | 修正理由+提案内容                 |
-| 修正前   | 原文引用                          |
-| 修正後   | 修正案\|"該当なし"\|"提案せず"    |
-| 修正理由 | 修正目的                          |
+| FIELD    | 値                                   |
+| -------- | ------------------------------------ |
+| Issue ID | `<section>-<3桁連番>`                |
+| 重要度   | S\|A\|B\|C\|E                        |
+| 指摘種別 | 修正必須\|注意喚起\|判断保留         |
+| 改善点   | 修正理由+提案内容                    |
+| 修正前   | 原文引用                             |
+| 修正後   | 修正案\|"該当なし"\|"提案せず"       |
+| 修正理由 | 修正目的                             |
 | 検証根拠 | :link参照URL\|"検証不能"\|"一般常識" |
 
 **指摘種別**:
@@ -1122,62 +1127,63 @@ Issue ID ::= <section>-<nnn>  ; section=小文字英数字, nnn=001-999
 
 #### レビュー指示1: 文章表現・スタイル
 
-| Pri | 観点             | ルール                                               |
-| --- | ---------------- | ---------------------------------------------------- |
+| Pri | 観点             | ルール                                                        |
+| --- | ---------------- | ------------------------------------------------------------- |
 | S   | 非レビュー領域   | DSL/DEF/RULE/CONSTRAINT/BEGIN INPUT-END INPUT/Appendix=対象外 |
-| S   | :remark指定      | 一切変更禁止                                         |
-| S   | 半角括弧         | ()維持                                               |
-| S   | コードブロック   | 誤字脱字のみ修正可                                   |
-| S   | ASCII            | 英数字・記号=半角(可読性優先可)                      |
-| S   | バックティック   | 技術用語/コード/コマンド/ファイル名=`囲み`           |
-| S   | 論理飛躍排除     | 論理的矛盾・飛躍を排除                               |
-| S   | 技術的正確性     | :role/:link基準                                      |
-| A   | 文法・表現・語彙 | 誤字脱字、不自然表現、送り仮名、助詞連続修正         |
-| A   | バランス         | 技術文書⇔カジュアルブログ                            |
-| A   | キーワード注釈   | 重要キーワード抽出+注釈                              |
-| A   | 箇条書き簡潔化   | 箇条書き=簡潔                                        |
-| A   | Markdown準拠     | Markdown記法遵守                                     |
-| B   | 本文文体         | ですます調                                           |
-| B   | 箇条書き文体     | である調/体言止め                                    |
-| B   | 手順文体         | 1行目=体言止め, 2行目以降=ですます調可               |
-| B   | 人称表現禁止     | 「私は」「あなたは」不使用                           |
-| B   | 指示表現原則禁止 | 「～しましょう」不使用(提案表現可)                   |
-| B   | 送り仮名平仮名   | 平仮名                                               |
-| B   | 「行なう」       | 「行う」→「行なう」                                  |
-| B   | 変数反映         | :role/:theme/:target/:goal/:link/:remark基準推敲     |
-| E   | 固有表現保持     | "Enjoy!", "Happy Hacking!", "atsushifx です"=変更禁止 |
-| E   | 口語トーン       | カジュアル・口語的                                   |
+| S   | :remark指定      | 一切変更禁止                                                  |
+| S   | 半角括弧         | ()維持                                                        |
+| S   | コードブロック   | 誤字脱字のみ修正可                                            |
+| S   | ASCII            | 英数字・記号=半角(可読性優先可)                               |
+| S   | バックティック   | 技術用語/コード/コマンド/ファイル名=`囲み`                    |
+| S   | 論理飛躍排除     | 論理的矛盾・飛躍を排除                                        |
+| S   | 技術的正確性     | :role/:link基準                                               |
+| A   | 文法・表現・語彙 | 誤字脱字、不自然表現、送り仮名、助詞連続修正                  |
+| A   | バランス         | 技術文書⇔カジュアルブログ                                     |
+| A   | キーワード注釈   | 重要キーワード抽出+注釈                                       |
+| A   | 箇条書き簡潔化   | 箇条書き=簡潔                                                 |
+| A   | Markdown準拠     | Markdown記法遵守                                              |
+| B   | 本文文体         | ですます調                                                    |
+| B   | 箇条書き文体     | である調/体言止め                                             |
+| B   | 手順文体         | 1行目=体言止め, 2行目以降=ですます調可                        |
+| B   | 人称表現禁止     | 「私は」「あなたは」不使用                                    |
+| B   | 指示表現原則禁止 | 「～しましょう」不使用(提案表現可)                            |
+| B   | 送り仮名平仮名   | 平仮名                                                        |
+| B   | 「行なう」       | 「行う」→「行なう」                                           |
+| B   | 変数反映         | :role/:theme/:target/:goal/:link/:remark基準推敲              |
+| E   | 固有表現保持     | "Enjoy!", "Happy Hacking!", "atsushifx です"=変更禁止         |
+| E   | 口語トーン       | カジュアル・口語的                                            |
 
-**非対象** = DSL/RULE/INPUT block | Appendix | コードブロック(誤字のみ可)。禁止表現: 人称("私は"), 指示("しましょう")。固有表現保持: "Enjoy!", "Happy Hacking!", "atsushifx です"。
+非対象: DSL/RULE/INPUT block | Appendix | コードブロック(誤字のみ可)。
+禁止表現: 人称("私は"), 指示("しましょう")。固有表現保持: "Enjoy!", "Happy Hacking!", "atsushifx です"。
 
 **NOTE**: 非対象領域への指摘=全面禁止。無限ループ防止。
 
 **技術的正確性検証プロトコル**:
 
-| 条件            | 検証方法                                   | 検証失敗時                          |
-| --------------- | ------------------------------------------ | ----------------------------------- |
-| :link指定あり   | :linkから事実・仕様検証                    | 「判断保留」+「要出典」             |
-| :link古い(2年+) | 「注意喚起」+「リンク古い可能性」          | -                                   |
-| :link指定なし   | 一般技術常識照合                           | 「判断保留」+「検証不能(要出典)」   |
-| 推測・経験談    | 「判断保留」+「個人的見解可能性」          | -                                   |
-| 断定表現        | :linkなし→「注意喚起」+「推量表現推奨」    | -                                   |
+| 条件            | 検証方法                                | 検証失敗時                        |
+| --------------- | --------------------------------------- | --------------------------------- |
+| :link指定あり   | :linkから事実・仕様検証                 | 「判断保留」+「要出典」           |
+| :link古い(2年+) | 「注意喚起」+「リンク古い可能性」       | -                                 |
+| :link指定なし   | 一般技術常識照合                        | 「判断保留」+「検証不能(要出典)」 |
+| 推測・経験談    | 「判断保留」+「個人的見解可能性」       | -                                 |
+| 断定表現        | :linkなし→「注意喚起」+「推量表現推奨」 | -                                 |
 
 **CONSTRAINT**: 検証失敗時={指摘種別="判断保留", 検証根拠="検証不能", 修正後="提案せず", 改善点="要出典"含む}。プロトコル=判定一貫性保証、両極端防止。
 
 #### レビュー指示2: 文章構成・理路
 
-| 観点 | 確認内容 |
-|------|---------|
+| 観点 | 確認内容                                                       |
+| ---- | -------------------------------------------------------------- |
 | 構成 | セクション構成適切性、セクション間連携、論理展開明確性・自然性 |
-| 要件 | 前提条件明示、論理的導出、遷移滑らか、段階的理解可能 |
+| 要件 | 前提条件明示、論理的導出、遷移滑らか、段階的理解可能           |
 
 #### レビュー指示3: スタイルガイド準拠
 
-| 観点           | ルール                   |
-| -------------- | ------------------------ |
-| :style準拠     | 指定スタイルガイド遵守   |
-| 優先順位       | レビュー指示1>スタイル   |
-| 特定表現許容   | 文末'!', ':'許容         |
+| 観点         | ルール                 |
+| ------------ | ---------------------- |
+| :style準拠   | 指定スタイルガイド遵守 |
+| 優先順位     | レビュー指示1>スタイル |
+| 特定表現許容 | 文末'!', ':'許容       |
 
 **NOTE**: デフォルトスタイル=GitHub。優先順位: レビュー指示1(文章表現)>スタイルガイド。許容例外: 文末感嘆符(カジュアル表現), コロン(説明・列挙導入)。
 
@@ -1185,39 +1191,39 @@ Issue ID ::= <section>-<nnn>  ; section=小文字英数字, nnn=001-999
 
 **モード決定ロジック**:
 
-| 優先度 | ソース                      | 設定方法                          |
-| ------ | --------------------------- | --------------------------------- |
-| 1      | コマンドフラグ              | /review --proposal=FORCE          |
-| 2      | SESSION変数                 | /set :proposal_mode = "OFF"       |
-| 3      | システムデフォルト          | AUTO (初期値)                     |
+| 優先度 | ソース             | 設定方法                    |
+| ------ | ------------------ | --------------------------- |
+| 1      | コマンドフラグ     | /review --proposal=FORCE    |
+| 2      | SESSION変数        | /set :proposal_mode = "OFF" |
+| 3      | システムデフォルト | AUTO (初期値)               |
 
 **モード別動作**:
 
-| モード | 生成条件                                      | 生成種別                       | FAIL_FAST 時 |
-| ------ | --------------------------------------------- | ------------------------------ | ------------ |
-| AUTO   | CATEGORY/VIOLATION/STATUS 条件に基づく選択的生成 | clarification, restructure, rephrase | ❌ 生成しない |
-| FORCE  | 全 findings に対して生成                       | + rewrite 許可                 | ✅ 生成する    |
-| OFF    | 生成しない                                    | -                              | ❌ 生成しない |
+| モード | 生成条件                                         | 生成種別                             | FAIL_FAST 時 |
+| ------ | ------------------------------------------------ | ------------------------------------ | ------------ |
+| AUTO   | CATEGORY/VIOLATION/STATUS 条件に基づく選択的生成 | clarification, restructure, rephrase | 生成しない   |
+| FORCE  | 全 findings に対して生成                         | + rewrite 許可                       | 生成する     |
+| OFF    | 生成しない                                       | -                                    | 生成しない   |
 
 **AUTO モード生成テーブル**:
 
-| Finding 属性           | 生成判定 | 許可種別                    |
-| ---------------------- | -------- | --------------------------- |
-| CATEGORY=inaccuracy    | ❌        | (skip - 事実確認必要)        |
-| CATEGORY=inconsistency | ✅        | clarification, restructure  |
-| CATEGORY=readability   | ✅        | rephrase                    |
-| CATEGORY=unknown       | ❌        | (skip - 判定不能)            |
-| VIOLATION 付き         | ❌        | (skip - ポリシー違反)        |
-| STATUS 付き            | ❌        | (skip - 判断保留)            |
+| Finding 属性           | 生成判定 | 許可種別                   |
+| ---------------------- | -------- | -------------------------- |
+| CATEGORY=inaccuracy    | skip     | (事実確認必要)             |
+| CATEGORY=inconsistency | ok       | clarification, restructure |
+| CATEGORY=readability   | ok       | rephrase                   |
+| CATEGORY=unknown       | skip     | (判定不能)                 |
+| VIOLATION 付き         | skip     | (ポリシー違反)             |
+| STATUS 付き            | skip     | (判断保留)                 |
 
 **種別選択ガイドライン**:
 
-| 種別          | 使用場面                              | 例                                      |
-| ------------- | ------------------------------------- | --------------------------------------- |
-| clarification | 不明瞭な表現を明確化                  | "それ" → 具体的な名詞に置き換え         |
-| restructure   | 構造的問題を再構成                    | パラグラフ順序変更、箇条書き化          |
-| rephrase      | 冗長表現を簡潔化                      | "〜することができる" → "〜できる"       |
-| rewrite       | 全面書き直し (FORCE のみ)             | センテンス全体の再構築                  |
+| 種別          | 使用場面                  | 例                                |
+| ------------- | ------------------------- | --------------------------------- |
+| clarification | 不明瞭な表現を明確化      | "それ" → 具体的な名詞に置き換え   |
+| restructure   | 構造的問題を再構成        | パラグラフ順序変更、箇条書き化    |
+| rephrase      | 冗長表現を簡潔化          | "〜することができる" → "〜できる" |
+| rewrite       | 全面書き直し (FORCE のみ) | センテンス全体の再構築            |
 
 **CONSTRAINT**:
 
@@ -1228,11 +1234,11 @@ Issue ID ::= <section>-<nnn>  ; section=小文字英数字, nnn=001-999
 
 ### 6.7 プロンプト共通変数
 
-| 変数   | スコープ | 用途                               | デフォルト |
-| ------ | -------- | ---------------------------------- | ---------- |
-| :role  | SESSION  | AIペルソナ定義 (レビュー品質基準)  | 下記リスト |
-| :style | SESSION  | スタイルガイド準拠基準             | "GitHub"   |
-| :newssite: | SESSION | ニュースサイト一覧             | 下記リスト |
+| 変数      | スコープ | 用途                              | デフォルト |
+| --------- | -------- | --------------------------------- | ---------- |
+| :role     | SESSION  | AIペルソナ定義 (レビュー品質基準) | 下記リスト |
+| :style    | SESSION  | スタイルガイド準拠基準            | "GitHub"   |
+| :newssite | SESSION  | ニュースサイト一覧                | 下記リスト |
 
 **NOTE**: :role=レビュー観点・品質基準の決定に使用。:style=表記ルール・文法規則の基準 (デフォルト優先度: レビュー指示1>スタイルガイド)。
 
@@ -1265,17 +1271,17 @@ output-phase   ::= ACCEPTANCE=PENDING (再実行可能)
 
 ### A.2 レビュー処理手順
 
-| 順序 | フェーズ         | 動作                                                          |
-| ---- | ---------------- | ------------------------------------------------------------- |
-| 1    | 入力検証         | EMIT ProcessStarted -> :buffer検証、必須変数確認              |
-| 2    | :role基準適用    | AIペルソナに基づく品質基準決定                                |
+| 順序 | フェーズ         | 動作                                                           |
+| ---- | ---------------- | -------------------------------------------------------------- |
+| 1    | 入力検証         | EMIT ProcessStarted -> :buffer検証、必須変数確認               |
+| 2    | :role基準適用    | AIペルソナに基づく品質基準決定                                 |
 | 3    | レビュー指示適用 | 指示1(文章表現)->指示2(文章構成)->指示3(スタイルガイド) 順適用 |
 | 4    | 改善点抽出       | 改善点特定 (Finding 生成)                                      |
 | 4.5  | 提案生成         | effective :proposal_mode に基づく Proposal 生成 (条件付き)     |
 | 5    | 結果整理         | 行番号順ソート                                                 |
 | 6    | 保存・出力       | :review保存、:appendix保存 (全体時)、出力形式整形              |
-| 7    | 完了             | EMIT ProcessCompleted -> ACCEPTANCE=PENDING                         |
-| 8    | エラー処理       | EMIT ProcessFailed -> ACCEPTANCE=PENDING                            |
+| 7    | 完了             | EMIT ProcessCompleted -> ACCEPTANCE=PENDING                    |
+| 8    | エラー処理       | EMIT ProcessFailed -> ACCEPTANCE=PENDING                       |
 
 **NOTE**: 利用可能コマンド=`/review [セクション]`, `/show [all|セクション]`, `/quickfix <fix>`, `/appendix`, `/chart`, `/begin`
 
@@ -1285,13 +1291,13 @@ output-phase   ::= ACCEPTANCE=PENDING (再実行可能)
 
 ### B.1 変数定義
 
-| 変数    | スコープ | 用途                         | 形式   | デフォルト |
-| ------- | -------- | ---------------------------- | ------ | ---------- |
-| :theme  | SESSION  | 記事テーマ (一貫性確認基準)  | string | ""         |
-| :target | SESSION  | 対象読者 (難易度判断基準)    | string | ""         |
-| :goal   | SESSION  | 記事目標 (構成展開適切性基準) | string | ""         |
-| :link   | SESSION  | 参考資料 (事実確認・仕様検証) | list   | ""         |
-| :remark | SESSION  | 追加指示 (優先度S相当)       | heredoc | ""         |
+| 変数    | スコープ | 用途                          | 形式    | デフォルト |
+| ------- | -------- | ----------------------------- | ------- | ---------- |
+| :theme  | SESSION  | 記事テーマ (一貫性確認基準)   | string  | ""         |
+| :target | SESSION  | 対象読者 (難易度判断基準)     | string  | ""         |
+| :goal   | SESSION  | 記事目標 (構成展開適切性基準) | string  | ""         |
+| :link   | SESSION  | 参考資料 (事実確認・仕様検証) | list    | ""         |
+| :remark | SESSION  | 追加指示 (優先度S相当)        | heredoc | ""         |
 
 **NOTE**: :theme=一貫性軸、:target=難易度判断、:goal=構成適切性、:link=事実検証、:remark=最優先。
 
@@ -1299,7 +1305,10 @@ output-phase   ::= ACCEPTANCE=PENDING (再実行可能)
 BEGIN INPUT
 /set :theme = "GitHub Reusable Workflowsを用いた組織横断CI/CD基盤の設計と運用"
 /set :target = "GitHub Actionsを既に利用しており、複数リポジトリ間で設定がばらつき、保守・更新の手間に課題を感じているエンジニア。CI/CDの基本は理解済みだが、組織的な統一や再現性の確保に踏み込めていない段階の読者。"
-/set :goal = "Reusable Workflowsによる統一的なCI/CD基盤の構築方法を理解し、Composite ActionsやWorkflow Templatesとの比較軸に基づいた選択、実務エラー回避(secrets: inherit制約、permissions未指定リスク、private repo SHA問題)、および「設計可能な境界」としての本質的価値を把握できる。"
+/set :goal = |
+  Reusable Workflowsによる統一的なCI/CD基盤の構築方法を理解し、Composite ActionsやWorkflow Templatesとの
+  比較軸に基づいた選択、実務エラー回避(secrets: inherit制約、permissions未指定リスク、private repo SHA問題)、
+  および「設計可能な境界」としての本質的価値を把握できる。
 /set :link = |
 - <https://docs.github.com/ja/actions/how-tos/reuse-automations/reuse-workflows> (ワークフローを再利用する - GitHub公式ドキュメント)
 - <https://docs.github.com/ja/actions/concepts/security> (GitHub Actionsのセキュリティ - GitHub公式ドキュメント)

--- a/tech-articles-prompt/article-writer.prompt
+++ b/tech-articles-prompt/article-writer.prompt
@@ -12,6 +12,8 @@ meta:
     - Copyright (c) 2025 atsushifx <https://github.com/atsushifx/>
 ---
 
+<!-- markdownlint-disable line-length -->
+
 ## Overview (概要)
 
 ## 0. メタ記法
@@ -61,7 +63,7 @@ block-type = DSL / MACRO / RULE / INPUT / OUTPUT
 
 ### 0.2 最小使用例
 
-```
+```text
 BEGIN INPUT
   SET :buffer = """
 技術記事の内容をここに記述します。
@@ -253,14 +255,14 @@ generation-status ::= DRAFT | INCOMPLETE | READY ; 初期=DRAFT
 
 ### 2.5 コマンド制約
 
-| コマンド         | ACCEPTANCE要求 | 副作用                                              | 再入 |
-| ---------------- | -------------- | --------------------------------------------------- | ---- |
-| /begin           | *              | CLEAR :buffer                                       | 可   |
-| /end             | *              | :buffer確定                                         | -    |
-| /write, /w [section] | PENDING    | ACCEPTANCE=ACTIVE (一時), EXEC_MODE: idle→proc→idle | 禁止 |
-| /exit            | *              | CLEAR ALL, EXEC_MODE=idle                           | -    |
-| /reset           | *              | CLEAR :var.. (スコープ内のみ)                       | -    |
-| /set             | *              | SET :var=value (スコープ内上書き許可)               | -    |
+| コマンド             | ACCEPTANCE要求 | 副作用                                              | 再入 |
+| -------------------- | -------------- | --------------------------------------------------- | ---- |
+| /begin               | *              | CLEAR :buffer                                       | 可   |
+| /end                 | *              | :buffer確定                                         | -    |
+| /write, /w [section] | PENDING        | ACCEPTANCE=ACTIVE (一時), EXEC_MODE: idle→proc→idle | 禁止 |
+| /exit                | *              | CLEAR ALL, EXEC_MODE=idle                           | -    |
+| /reset               | *              | CLEAR :var.. (スコープ内のみ)                       | -    |
+| /set                 | *              | SET :var=value (スコープ内上書き許可)               | -    |
 
 **NOTE**: /write, /w = ACCEPTANCE一時ACTIVE化、EXEC_MODE遷移必須、再入禁止。他コマンドはACCEPTANCE状態不問。
 
@@ -451,9 +453,10 @@ RULE FAIL_FAST:
 
 **判定基準 (形式化・検出方法)**:
 
-| 条件                | 検出方法                                          | 閾値                   | 根拠             |
-| ------------------- | ------------------------------------------------- | ---------------------- | ---------------- |
-| structural_collapse | 見出し階層飛び: `^#{1,6}` regex, 必須section欠落  | gap>1 OR 概要/結論なし | 構造破綻         |
+| 条件                | 検出方法                                         | 閾値                   | 根拠     |
+| ------------------- | ------------------------------------------------ | ---------------------- | -------- |
+| structural_collapse | 見出し階層飛び: `^#{1,6}` regex, 必須section欠落 | gap>1 OR 概要/結論なし | 構造破綻 |
+
 | technical_fatality  | コードブロック未閉: `` ``` `` ペア不整合, API誤用 | unclosed>0 OR errors≥3 | 実行不可能       |
 | unreadability       | 主題文欠落率, 接続詞密度                          | 欠落率>50% OR 接続<10% | 意図伝達不可     |
 | insufficient_length | Unicode文字数 (コードブロック除外)                | <500文字               | レビュー対象不足 |
@@ -539,14 +542,14 @@ END INPUT
 
 ### 4.2 標準コマンド
 
-| コマンド            | 動作                        | 値形式           |
-| ------------------- | --------------------------- | ---------------- |
-| /begin              | CLEAR :buffer               | -                |
-| /end                | :buffer確定                 | -                |
-| /write, /w [section] | ACCEPTANCE=ACTIVE(一時)    | -                |
-| /exit               | CLEAR ALL                   | -                |
-| /reset <:var..>     | CLEAR :var..                | -                |
-| /set <:var>=<value> | SET :var=value              | "text"\|\|\|"""" |
+| コマンド             | 動作                    | 値形式           |
+| -------------------- | ----------------------- | ---------------- |
+| /begin               | CLEAR :buffer           | -                |
+| /end                 | :buffer確定             | -                |
+| /write, /w [section] | ACCEPTANCE=ACTIVE(一時) | -                |
+| /exit                | CLEAR ALL               | -                |
+| /reset `<:var..>`    | CLEAR :var..            | -                |
+| /set `:var`=`value`  | SET :var=value          | "text"\|\|\|"""" |
 
 **NOTE**: `/w` は `/write` の完全なエイリアス。意味論的差異・副作用の違いは存在しない。
 
@@ -657,7 +660,7 @@ RejectResult:
 
 #### Finding形式 (順序固定)
 
-```
+```text
 指摘種別: 修正必須|注意喚起|判断保留
 CATEGORY: readability|inconsistency|inaccuracy|unknown
 PRIORITY: A|B|C|D|E
@@ -692,14 +695,14 @@ PRIORITY: A|B|C|D|E
 
 #### VIOLATION/STATUS定義
 
-| ラベル                       | タイプ | 効果                 | PRIORITY |
-| ---------------------------- | ------ | -------------------- | -------- |
-| VIOLATION: STYLE_OVERRIDE    | 違反   | 指摘をDに降格        | D        |
-| VIOLATION: INTENT_DISREGARD  | 違反   | ユーザー確認要求     | D        |
-| VIOLATION: SUBJECTIVE_BIAS   | 違反   | 指摘をEに降格        | E        |
-| VIOLATION: SCOPE_EXCESS      | 違反   | 範囲逸脱通知         | D        |
-| STATUS: QUESTION_REQUIRED    | 状態   | レビュー保留         | -        |
-| STATUS: CLARIFICATION_NEEDED | 状態   | 明確化要求           | -        |
+| ラベル                       | タイプ | 効果             | PRIORITY |
+| ---------------------------- | ------ | ---------------- | -------- |
+| VIOLATION: STYLE_OVERRIDE    | 違反   | 指摘をDに降格    | D        |
+| VIOLATION: INTENT_DISREGARD  | 違反   | ユーザー確認要求 | D        |
+| VIOLATION: SUBJECTIVE_BIAS   | 違反   | 指摘をEに降格    | E        |
+| VIOLATION: SCOPE_EXCESS      | 違反   | 範囲逸脱通知     | D        |
+| STATUS: QUESTION_REQUIRED    | 状態   | レビュー保留     | -        |
+| STATUS: CLARIFICATION_NEEDED | 状態   | 明確化要求       | -        |
 
 **CONSTRAINT**: enum拡張禁止 (closed: true) 。CATEGORY→PRIORITY写像は`:remark`で上書き可。VIOLATION付き指摘は自動降格、STATUS付きは保留状態。
 
@@ -709,22 +712,22 @@ PRIORITY: A|B|C|D|E
 
 ### 5.1 命名規則
 
-| 要素                     | 型           | 制約       | スタイル              | 例                   |
-| ------------------------ | ------------ | ---------- | --------------------- | -------------------- |
-| ACCEPTANCE/CMD/VAR/EVENT | `<ascii-id>` | 英数字-_   | snake_case/PascalCase | cmd, :buf, ModeChg   |
-| FIELD/RULE               | `<label>`    | 日本語許可 | -                     | 重要度, セクションID |
+| 要素                     | 型           | 制約       | スタイル              | 例                           |
+| ------------------------ | ------------ | ---------- | --------------------- | ---------------------------- |
+| ACCEPTANCE/CMD/VAR/EVENT | `<ascii-id>` | 英数字-_   | snake_case/PascalCase | cmd, :buf, ModeChg           |
+| FIELD/RULE               | `<label>`    | 日本語許可 | -                     | 重要度, セクションID         |
 | AS                       | -            | 表示名     | 日本語推奨            | ACCEPTANCE cmd AS "コマンド" |
 
 **NOTE**: コード参照=識別子 | LLM出力=AS優先。
 
 ### 5.2 コーディングスタイル
 
-| 項目     | 規則                                    |
-| -------- | --------------------------------------- |
-| 形式     | インライン (`->`, 120文字) \| ブロック  |
-| EXECUTE  | 1文=1責務、ACCEPTANCE遷移・SET明示      |
-| 制約     | CONSTRAINT/EVENT形式化                  |
-| 出力構造 | トレーサビリティ・再現性保証            |
+| 項目     | 規則                                   |
+| -------- | -------------------------------------- |
+| 形式     | インライン (`->`, 120文字) \| ブロック |
+| EXECUTE  | 1文=1責務、ACCEPTANCE遷移・SET明示     |
+| 制約     | CONSTRAINT/EVENT形式化                 |
+| 出力構造 | トレーサビリティ・再現性保証           |
 
 ### 5.3 EXECUTE 運用ガイドライン
 
@@ -807,10 +810,10 @@ generation-status ::= DRAFT | INCOMPLETE | READY ; 初期=DRAFT
 
 **ACCEPTANCE PRINCIPLE**: 合否評価ではなく受付・処理境界。PENDING=沈黙・蓄積のみ | ACTIVE=/write時のみ一時化。
 
-| 状態    | :buffer | 制約                                     | 遷移                 |
-| ------- | ------- | ---------------------------------------- | -------------------- |
+| 状態    | :buffer | 制約                                           | 遷移                |
+| ------- | ------- | ---------------------------------------------- | ------------------- |
 | PENDING | 構築中  | 解析禁止・沈黙維持・/begin,/end,/set,/exit受付 | /write→ACTIVE(一時) |
-| ACTIVE  | 確定    | /write実行中のみ出力許可                 | 完了→PENDING         |
+| ACTIVE  | 確定    | /write実行中のみ出力許可                       | 完了→PENDING        |
 
 **CONSTRAINT silent accumulation**: PENDING時=:buffer蓄積のみ、解析・要約・応答禁止。すべての処理は明示コマンドでのみ開始。LLMの自発動作=主導権侵害。
 
@@ -823,11 +826,11 @@ generation-status ::= DRAFT | INCOMPLETE | READY
 meta_state ::= none | rejected | generated  ; OUTPUT variant discriminator
 ```
 
-| ステータス | 意味                   | 遷移条件        |
-| ---------- | ---------------------- | --------------- |
-| DRAFT      | 生成開始状態           | /write 実行開始 |
+| ステータス | 意味                   | 遷移条件         |
+| ---------- | ---------------------- | ---------------- |
+| DRAFT      | 生成開始状態           | /write 実行開始  |
 | INCOMPLETE | 情報不足、追加入力必要 | 必須情報欠落検出 |
-| READY      | 生成完了、OUTPUT 許可  | 記事生成完了    |
+| READY      | 生成完了、OUTPUT 許可  | 記事生成完了     |
 
 **meta_state 協調** (判別共用体制御):
 
@@ -866,20 +869,20 @@ VAR REVIEW :article  ; 生成記事
 /write [<section>] ::= 記事生成実行(全体または特定セクション)
 ```
 
-| フェーズ | アクション                                          |
-| -------- | --------------------------------------------------- |
-| 前処理   | EXEC_MODE=processing, generation-status=DRAFT       |
-| 入力検証 | :buffer検証(定義・非空・50文字以上)                 |
-| 執筆     | 執筆指示適用、記事生成                              |
+| フェーズ | アクション                                              |
+| -------- | ------------------------------------------------------- |
+| 前処理   | EXEC_MODE=processing, generation-status=DRAFT           |
+| 入力検証 | :buffer検証(定義・非空・50文字以上)                     |
+| 執筆     | 執筆指示適用、記事生成                                  |
 | 後処理   | generation-status更新(READY/INCOMPLETE), EXEC_MODE=idle |
 
 **CONSTRAINT 入力検証**:
 
-| 項目        | 条件             | 失敗時アクション                                                |
-| ----------- | ---------------- | --------------------------------------------------------------- |
+| 項目        | 条件             | 失敗時アクション                                                     |
+| ----------- | ---------------- | -------------------------------------------------------------------- |
 | :buffer定義 | defined(:buffer) | generation-status=INCOMPLETE, EMIT ProcessFailed, ACCEPTANCE=PENDING |
 | :buffer非空 | length > 0       | generation-status=INCOMPLETE, EMIT ProcessFailed, ACCEPTANCE=PENDING |
-| 文字数      | length >= 50     | 警告("推奨: 50文字以上")                                        |
+| 文字数      | length >= 50     | 警告("推奨: 50文字以上")                                             |
 
 **NOTE**: 検証失敗時=INCOMPLETE設定→OUTPUT禁止。/write=記事生成唯一コマンド(状態機械単純化、予測可能性保証)。
 
@@ -901,21 +904,21 @@ VAR REVIEW :article  ; 生成記事
 
 #### 執筆指示1: 基本構成・文章表現
 
-| Pri | 観点             | ルール                                                    |
-| --- | ---------------- | --------------------------------------------------------- |
-| S   | 下書き展開       | :buffer内容をベースにセクション詳細化                     |
-| S   | 参考記事学習     | zenn.dev/atsushifx最新12記事スタイル学習(不可時=一般構成) |
-| S   | 技術的正確性     | :link参照で事実・仕様検証                                 |
-| S   | 変数反映         | :theme/:goal/:target/:role/:remark反映                    |
-| S   | ASCII使用        | 英数字・記号=半角(読みやすさ優先時は全角可)               |
-| S   | 固有表現保持     | "Enjoy!", "Happy Hacking!", "atsushifx です"=変更禁止     |
-| A   | 基本文体         | ですます調基調(口語的表現適宜可)                          |
-| A   | トーンバランス   | 技術性⇔カジュアルブログ                                   |
-| A   | 人称表現禁止     | 「私は」「あなたは」不使用                                |
-| A   | 指示表現禁止     | 「～しましょう」不使用(提案表現可)                        |
-| A   | 箇条書き簡潔化   | 体言止め                                                  |
-| B   | テキスト図解     | ASCII等で視覚化                                           |
-| B   | mermaid.js図     | フローチャート・シーケンス図作成                          |
+| Pri | 観点           | ルール                                                    |
+| --- | -------------- | --------------------------------------------------------- |
+| S   | 下書き展開     | :buffer内容をベースにセクション詳細化                     |
+| S   | 参考記事学習   | zenn.dev/atsushifx最新12記事スタイル学習(不可時=一般構成) |
+| S   | 技術的正確性   | :link参照で事実・仕様検証                                 |
+| S   | 変数反映       | :theme/:goal/:target/:role/:remark反映                    |
+| S   | ASCII使用      | 英数字・記号=半角(読みやすさ優先時は全角可)               |
+| S   | 固有表現保持   | "Enjoy!", "Happy Hacking!", "atsushifx です"=変更禁止     |
+| A   | 基本文体       | ですます調基調(口語的表現適宜可)                          |
+| A   | トーンバランス | 技術性⇔カジュアルブログ                                   |
+| A   | 人称表現禁止   | 「私は」「あなたは」不使用                                |
+| A   | 指示表現禁止   | 「～しましょう」不使用(提案表現可)                        |
+| A   | 箇条書き簡潔化 | 体言止め                                                  |
+| B   | テキスト図解   | ASCII等で視覚化                                           |
+| B   | mermaid.js図   | フローチャート・シーケンス図作成                          |
 
 **NOTE**: 参考記事学習=抽象的模倣指針。禁止例: 人称(❌「私は～」→⭕「推奨」), 指示(❌「～しましょう」→⭕「～します」)。
 
@@ -959,15 +962,15 @@ output-phase   ::= ACCEPTANCE=PENDING (再入力可能)
 
 ### A.2 執筆処理手順
 
-| 順序 | フェーズ     | 動作                                              |
-| ---- | ------------ | ------------------------------------------------- |
-| 1    | 入力検証     | EMIT ProcessStarted -> :buffer検証、必須変数確認  |
+| 順序 | フェーズ     | 動作                                                |
+| ---- | ------------ | --------------------------------------------------- |
+| 1    | 入力検証     | EMIT ProcessStarted -> :buffer検証、必須変数確認    |
 | 2    | 参考情報確認 | zenn.dev/atsushifx最新12記事スタイル学習、:link検証 |
-| 3    | 執筆実行     | 重要度(S/A/B)適用、:buffer展開、セクション詳細化 |
-| 4    | 部分作成     | セクション指定時=該当セクションのみ処理           |
-| 5    | 保存・出力   | :article保存                                      |
-| 6    | 完了         | EMIT ProcessCompleted -> ACCEPTANCE=PENDING       |
-| 7    | エラー処理   | EMIT ProcessFailed -> ACCEPTANCE=PENDING          |
+| 3    | 執筆実行     | 重要度(S/A/B)適用、:buffer展開、セクション詳細化    |
+| 4    | 部分作成     | セクション指定時=該当セクションのみ処理             |
+| 5    | 保存・出力   | :article保存                                        |
+| 6    | 完了         | EMIT ProcessCompleted -> ACCEPTANCE=PENDING         |
+| 7    | エラー処理   | EMIT ProcessFailed -> ACCEPTANCE=PENDING            |
 
 **NOTE**: 利用可能コマンド=`/write [セクション]`, `/begin`。
 


### PR DESCRIPTION
## Overview

**Summary**
Standardizes Markdown formatting across DSL specs and prompt files, and adds linter rules to maintain quality going forward.

**Background / Motivation**
The DSL spec files and prompt files had inconsistent Markdown: missing code block language annotations, misaligned tables, and varied heading/list styles. This PR cleans up those inconsistencies and adds textlint and markdownlint rules so the same issues cannot recur.

## Changes

### Core Changes

- `dsl/llm-control-language-spec.md`: Remove bold emphasis from list items, normalize spacing around reference links, add TOC entry for proposal generation section
- `dsl/llm-control-language-spec-compact.md`: Normalize labels to plain text, change `technical_fatality` fallback from `SKIP` to `INCOMPLETE`, fix code block language annotations
- `tech-articles-prompt/article-proofreading.prompt`: Add language annotations to code blocks, fix table alignment, unify command/note styles, add line-length directive
- `tech-articles-prompt/article-writer.prompt`: Add overview section, fix code block annotations, improve table alignment and spacing, add trailing newline
- `tech-articles-prompt/article-review.prompt`: Apply the same Markdown consistency fixes as the other prompt files

### Test Updates

N/A (documentation and configuration changes only)

### Removed

- `configs/.markdownlint-cli2.yaml`: Remove `**/*.md` and `**/*.prompt` glob patterns from `globs` section (scope cleanup)

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Closes #53

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

The `technical_fatality` fallback change (`SKIP` → `INCOMPLETE`) in the compact DSL spec is a semantic fix — `INCOMPLETE` more accurately reflects that the evaluation could not be completed, rather than being skipped intentionally.
